### PR TITLE
fix: address all 8 security vulnerabilities from audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ const mismatchedPixels: number = comparePng(
     img1, // First PNG: absolute file path or Buffer
     img2, // Second PNG: absolute file path or Buffer
     {
-        excludedAreas,              // Regions to skip during comparison. Default: []
-        diffFilePath,               // Path to write the diff PNG (only written when mismatch > 0). Default: undefined
+        excludedAreas, // Regions to skip during comparison. Default: []
+        diffFilePath, // Path to write the diff PNG (only written when mismatch > 0). Default: undefined
         throwErrorOnInvalidInputData, // Throw on missing/invalid input. Default: true
-        extendedAreaColor,          // Color used for size-padding regions. Default: { r: 0, g: 255, b: 0 }
-        excludedAreaColor,          // Color used for excluded areas. Default: { r: 0, g: 0, b: 255 }
-        maxDimension,               // Max allowed image width/height in px. Always throws if exceeded. Default: 16384
-        diffOutputBaseDir,          // Restrict diffFilePath writes to this directory (path-traversal guard). Default: undefined
-        inputBaseDir,               // Restrict png1/png2 reads to this directory (path-traversal guard). Default: undefined
-        pixelmatchOptions,          // Options forwarded to pixelmatch. Default: undefined
+        extendedAreaColor, // Color used for size-padding regions. Default: { r: 0, g: 255, b: 0 }
+        excludedAreaColor, // Color used for excluded areas. Default: { r: 0, g: 0, b: 255 }
+        maxDimension, // Max allowed image width/height in px. Always throws if exceeded. Default: 16384
+        diffOutputBaseDir, // Restrict diffFilePath writes to this directory (path-traversal guard). Default: undefined
+        inputBaseDir, // Restrict png1/png2 reads to this directory (path-traversal guard). Default: undefined
+        pixelmatchOptions, // Options forwarded to pixelmatch. Default: undefined
     },
 );
 
@@ -85,17 +85,17 @@ Compares two PNG images pixel-by-pixel and returns the number of mismatched pixe
 
 ### `ComparePngOptions`
 
-| Option                         | Type                | Default                  | Description                                                                                                                                                                                                                    |
-| ------------------------------ | ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `excludedAreas`                | `Area[]`            | `[]`                     | Rectangular regions to exclude from comparison (painted on both images before diffing, so they always match)                                                                                                                   |
-| `diffFilePath`                 | `string`            | `undefined`              | File path for the diff PNG. Only written when `result > 0`                                                                                                                                                                     |
-| `throwErrorOnInvalidInputData` | `boolean`           | `true`                   | Throw on missing/unsupported input. Set to `false` to treat invalid input as a zero-size PNG. An error is always thrown when **both** inputs are invalid                                                                       |
-| `extendedAreaColor`            | `Color`             | `{ r: 0, g: 255, b: 0 }` | Fill colour for padded regions when images differ in size. Override when the default green clashes with your image content                                                                                                     |
-| `excludedAreaColor`            | `Color`             | `{ r: 0, g: 0, b: 255 }` | Fill colour applied to `excludedAreas` on both images before comparison. Override when the default blue clashes with your image content                                                                                        |
-| `maxDimension`                 | `number`            | `16384`                  | Maximum allowed width or height (px) for either input image. **Always throws when exceeded, regardless of `throwErrorOnInvalidInputData`.** Set to `Infinity` to disable. Protects against DoS via crafted PNG headers        |
-| `diffOutputBaseDir`            | `string`            | `undefined`              | When set, `diffFilePath` must resolve to a path **inside** this directory. Any attempt to write outside it throws `"Path traversal detected"`. Use in server-side contexts where `diffFilePath` may be caller-controlled      |
+| Option                         | Type                | Default                  | Description                                                                                                                                                                                                                          |
+| ------------------------------ | ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `excludedAreas`                | `Area[]`            | `[]`                     | Rectangular regions to exclude from comparison (painted on both images before diffing, so they always match)                                                                                                                         |
+| `diffFilePath`                 | `string`            | `undefined`              | File path for the diff PNG. Only written when `result > 0`                                                                                                                                                                           |
+| `throwErrorOnInvalidInputData` | `boolean`           | `true`                   | Throw on missing/unsupported input. Set to `false` to treat invalid input as a zero-size PNG. An error is always thrown when **both** inputs are invalid                                                                             |
+| `extendedAreaColor`            | `Color`             | `{ r: 0, g: 255, b: 0 }` | Fill colour for padded regions when images differ in size. Override when the default green clashes with your image content                                                                                                           |
+| `excludedAreaColor`            | `Color`             | `{ r: 0, g: 0, b: 255 }` | Fill colour applied to `excludedAreas` on both images before comparison. Override when the default blue clashes with your image content                                                                                              |
+| `maxDimension`                 | `number`            | `16384`                  | Maximum allowed width or height (px) for either input image. **Always throws when exceeded, regardless of `throwErrorOnInvalidInputData`.** Set to `Infinity` to disable. Protects against DoS via crafted PNG headers               |
+| `diffOutputBaseDir`            | `string`            | `undefined`              | When set, `diffFilePath` must resolve to a path **inside** this directory. Any attempt to write outside it throws `"Path traversal detected"`. Use in server-side contexts where `diffFilePath` may be caller-controlled             |
 | `inputBaseDir`                 | `string`            | `undefined`              | When set, string input paths (`png1` / `png2`) must resolve to a path **inside** this directory. Any attempt to read outside it throws `"Path traversal detected"`. Use in server-side contexts where paths may be caller-controlled |
-| `pixelmatchOptions`            | `PixelmatchOptions` | `undefined`              | Options forwarded to [pixelmatch](https://github.com/mapbox/pixelmatch)                                                                                                                                                        |
+| `pixelmatchOptions`            | `PixelmatchOptions` | `undefined`              | Options forwarded to [pixelmatch](https://github.com/mapbox/pixelmatch)                                                                                                                                                              |
 
 ---
 
@@ -138,11 +138,11 @@ type Color = {
 
 ### Exported constants
 
-| Constant                      | Value                    | Description                                                                                              |
-| ----------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `DEFAULT_EXTENDED_AREA_COLOR` | `{ r: 0, g: 255, b: 0 }` | Default fill colour for size-extended padding regions                                                    |
-| `DEFAULT_EXCLUDED_AREA_COLOR` | `{ r: 0, g: 0, b: 255 }` | Default fill colour for excluded areas                                                                   |
-| `DEFAULT_MAX_DIMENSION`       | `16384`                  | Default maximum image dimension (px). Import this constant when you want to reference the default value  |
+| Constant                      | Value                    | Description                                                                                             |
+| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_EXTENDED_AREA_COLOR` | `{ r: 0, g: 255, b: 0 }` | Default fill colour for size-extended padding regions                                                   |
+| `DEFAULT_EXCLUDED_AREA_COLOR` | `{ r: 0, g: 0, b: 255 }` | Default fill colour for excluded areas                                                                  |
+| `DEFAULT_MAX_DIMENSION`       | `16384`                  | Default maximum image dimension (px). Import this constant when you want to reference the default value |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,15 @@ const mismatchedPixels: number = comparePng(
     img1, // First PNG: absolute file path or Buffer
     img2, // Second PNG: absolute file path or Buffer
     {
-        excludedAreas, // Regions to skip during comparison. Default: []
-        diffFilePath, // Path to write the diff PNG (only written when mismatch > 0). Default: undefined
+        excludedAreas,              // Regions to skip during comparison. Default: []
+        diffFilePath,               // Path to write the diff PNG (only written when mismatch > 0). Default: undefined
         throwErrorOnInvalidInputData, // Throw on missing/invalid input. Default: true
-        extendedAreaColor, // Color used for size-padding regions. Default: { r: 0, g: 255, b: 0 }
-        excludedAreaColor, // Color used for excluded areas. Default: { r: 0, g: 0, b: 255 }
-        pixelmatchOptions, // Options forwarded to pixelmatch. Default: undefined
+        extendedAreaColor,          // Color used for size-padding regions. Default: { r: 0, g: 255, b: 0 }
+        excludedAreaColor,          // Color used for excluded areas. Default: { r: 0, g: 0, b: 255 }
+        maxDimension,               // Max allowed image width/height in px. Always throws if exceeded. Default: 16384
+        diffOutputBaseDir,          // Restrict diffFilePath writes to this directory (path-traversal guard). Default: undefined
+        inputBaseDir,               // Restrict png1/png2 reads to this directory (path-traversal guard). Default: undefined
+        pixelmatchOptions,          // Options forwarded to pixelmatch. Default: undefined
     },
 );
 
@@ -82,14 +85,17 @@ Compares two PNG images pixel-by-pixel and returns the number of mismatched pixe
 
 ### `ComparePngOptions`
 
-| Option                         | Type                | Default                  | Description                                                                                                                                              |
-| ------------------------------ | ------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `excludedAreas`                | `Area[]`            | `[]`                     | Rectangular regions to exclude from comparison (painted on both images before diffing, so they always match)                                             |
-| `diffFilePath`                 | `string`            | `undefined`              | File path for the diff PNG. Only written when `result > 0`                                                                                               |
-| `throwErrorOnInvalidInputData` | `boolean`           | `true`                   | Throw on missing/unsupported input. Set to `false` to treat invalid input as a zero-size PNG. An error is always thrown when **both** inputs are invalid |
-| `extendedAreaColor`            | `Color`             | `{ r: 0, g: 255, b: 0 }` | Fill colour for padded regions when images differ in size. Override when the default green clashes with your image content                               |
-| `excludedAreaColor`            | `Color`             | `{ r: 0, g: 0, b: 255 }` | Fill colour applied to `excludedAreas` on both images before comparison. Override when the default blue clashes with your image content                  |
-| `pixelmatchOptions`            | `PixelmatchOptions` | `undefined`              | Options forwarded to [pixelmatch](https://github.com/mapbox/pixelmatch)                                                                                  |
+| Option                         | Type                | Default                  | Description                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `excludedAreas`                | `Area[]`            | `[]`                     | Rectangular regions to exclude from comparison (painted on both images before diffing, so they always match)                                                                                                                   |
+| `diffFilePath`                 | `string`            | `undefined`              | File path for the diff PNG. Only written when `result > 0`                                                                                                                                                                     |
+| `throwErrorOnInvalidInputData` | `boolean`           | `true`                   | Throw on missing/unsupported input. Set to `false` to treat invalid input as a zero-size PNG. An error is always thrown when **both** inputs are invalid                                                                       |
+| `extendedAreaColor`            | `Color`             | `{ r: 0, g: 255, b: 0 }` | Fill colour for padded regions when images differ in size. Override when the default green clashes with your image content                                                                                                     |
+| `excludedAreaColor`            | `Color`             | `{ r: 0, g: 0, b: 255 }` | Fill colour applied to `excludedAreas` on both images before comparison. Override when the default blue clashes with your image content                                                                                        |
+| `maxDimension`                 | `number`            | `16384`                  | Maximum allowed width or height (px) for either input image. **Always throws when exceeded, regardless of `throwErrorOnInvalidInputData`.** Set to `Infinity` to disable. Protects against DoS via crafted PNG headers        |
+| `diffOutputBaseDir`            | `string`            | `undefined`              | When set, `diffFilePath` must resolve to a path **inside** this directory. Any attempt to write outside it throws `"Path traversal detected"`. Use in server-side contexts where `diffFilePath` may be caller-controlled      |
+| `inputBaseDir`                 | `string`            | `undefined`              | When set, string input paths (`png1` / `png2`) must resolve to a path **inside** this directory. Any attempt to read outside it throws `"Path traversal detected"`. Use in server-side contexts where paths may be caller-controlled |
+| `pixelmatchOptions`            | `PixelmatchOptions` | `undefined`              | Options forwarded to [pixelmatch](https://github.com/mapbox/pixelmatch)                                                                                                                                                        |
 
 ---
 
@@ -132,10 +138,11 @@ type Color = {
 
 ### Exported constants
 
-| Constant                      | Value                    | Description                                           |
-| ----------------------------- | ------------------------ | ----------------------------------------------------- |
-| `DEFAULT_EXTENDED_AREA_COLOR` | `{ r: 0, g: 255, b: 0 }` | Default fill colour for size-extended padding regions |
-| `DEFAULT_EXCLUDED_AREA_COLOR` | `{ r: 0, g: 0, b: 255 }` | Default fill colour for excluded areas                |
+| Constant                      | Value                    | Description                                                                                              |
+| ----------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_EXTENDED_AREA_COLOR` | `{ r: 0, g: 255, b: 0 }` | Default fill colour for size-extended padding regions                                                    |
+| `DEFAULT_EXCLUDED_AREA_COLOR` | `{ r: 0, g: 0, b: 255 }` | Default fill colour for excluded areas                                                                   |
+| `DEFAULT_MAX_DIMENSION`       | `16384`                  | Default maximum image dimension (px). Import this constant when you want to reference the default value  |
 
 ---
 

--- a/VULNERABILITY_REPORT.md
+++ b/VULNERABILITY_REPORT.md
@@ -1,0 +1,378 @@
+# Vulnerability Report — png-visual-compare
+
+**Project:** png-visual-compare v4.1.0
+**Date:** 2026-03-31
+**Scope:** Source code audit (TypeScript library + developer tool)
+**Auditor:** Security analysis via CTF review
+
+---
+
+## Summary
+
+| ID     | Severity | Title                                                    | File                                           |
+| ------ | -------- | -------------------------------------------------------- | ---------------------------------------------- |
+| VUL-01 | CRITICAL | Path Traversal → Arbitrary File Write                    | `src/comparePng.ts:100-102`                    |
+| VUL-02 | HIGH     | Arbitrary File Read via Unsanitized Path                 | `src/getPngData.ts:23`                         |
+| VUL-03 | HIGH     | Integer Overflow in Pixel Position (Bitshift)            | `src/fillImageSizeDifference.ts:21`            |
+| VUL-04 | HIGH     | Denial of Service via Crafted PNG Dimensions             | `src/comparePng.ts:68-71`                      |
+| VUL-05 | MEDIUM   | Filesystem Enumeration via Error Message Differentiation | `src/getPngData.ts:26-28`                      |
+| VUL-06 | MEDIUM   | No Runtime Validation of Color Channel Values            | `src/drawPixelOnBuff.ts`, `src/types/color.ts` |
+| VUL-07 | LOW      | Duplicate `URL.revokeObjectURL` Call                     | `tools/excluded-areas-builder.html:391-392`    |
+| VUL-08 | LOW      | Missing Content-Security-Policy in Developer Tool        | `tools/excluded-areas-builder.html`            |
+
+---
+
+## VUL-01 — CRITICAL: Path Traversal → Arbitrary File Write
+
+**File:** `src/comparePng.ts:99-102`
+**CWE:** CWE-22 (Path Traversal), CWE-73 (External Control of File Name or Path)
+
+### Description
+
+The `diffFilePath` option is accepted as a caller-controlled string and passed — with only `path.resolve()` normalization, no whitelist or containment check — directly to `mkdirSync` and `writeFileSync`. This allows any caller to write a valid PNG-format file to **any path on the filesystem** that the process has permission to write to, including creating arbitrary directory trees.
+
+### Vulnerable Code
+
+```ts
+// comparePng.ts:99-102
+if (pixelmatchResult > 0 && shouldCreateDiffFile) {
+    const diffFilePath = resolve(opts?.diffFilePath as string); // resolves but does NOT restrict
+    mkdirSync(parse(diffFilePath).dir, { recursive: true }); // creates arbitrary directories
+    writeFileSync(diffFilePath, PNG.sync.write(diff)); // writes PNG to arbitrary path
+}
+```
+
+### Proof of Concept
+
+```ts
+// Write a file to /tmp/evil/payload.png (or any writable path)
+comparePng(validPng1, validPng2, { diffFilePath: '/tmp/evil/payload.png' });
+
+// Traverse to a sensitive location
+comparePng(validPng1, validPng2, { diffFilePath: '../../../../etc/cron.d/backdoor' });
+
+// Overwrite any file with PNG binary content
+comparePng(validPng1, validPng2, { diffFilePath: '/home/user/.ssh/authorized_keys' });
+```
+
+### Impact
+
+- Write arbitrary binary data (a valid PNG) to any filesystem path the process can access.
+- Create arbitrary directory trees anywhere on the filesystem.
+- In a server-side context where user input reaches `diffFilePath`, this is a full **remote code execution** primitive (e.g., writing to cron directories, web roots, or shell config files).
+
+### Remediation
+
+Validate that the resolved `diffFilePath` is within a permitted base directory before writing:
+
+```ts
+const safeDir = resolve('./diff-output');
+const resolved = resolve(opts.diffFilePath);
+if (!resolved.startsWith(safeDir + path.sep)) {
+    throw new Error('diffFilePath must be within the allowed output directory');
+}
+```
+
+---
+
+## VUL-02 — HIGH: Arbitrary File Read via Unsanitized Path
+
+**File:** `src/getPngData.ts:20-31`
+**CWE:** CWE-22 (Path Traversal), CWE-73 (External Control of File Name or Path)
+
+### Description
+
+When `pngSource` is a string, it is passed directly to `readFileSync()` without any path sanitization. Any file accessible to the process can be read. If the file is a valid PNG, its pixel data is returned and usable by the caller. If not, the error message leaks the OS-level error (see VUL-05).
+
+### Vulnerable Code
+
+```ts
+// getPngData.ts:23
+png = readFileSync(pngSource); // no path validation — reads any file
+```
+
+### Proof of Concept
+
+```ts
+// Read /etc/passwd — will fail PNG parse, but the file IS read from disk
+// before the PNG parser rejects it
+comparePng('/etc/passwd', validPng, { throwErrorOnInvalidInputData: false });
+
+// If an attacker controls png1/png2 in a server context, they can probe
+// any readable file path
+```
+
+### Impact
+
+- Arbitrary read of any file the process can access.
+- Combined with a side-channel on error messages (VUL-05), enables full filesystem enumeration.
+- In a server context where user input reaches `png1`/`png2`, this constitutes a **Local File Read** vulnerability.
+
+### Remediation
+
+Validate that file paths are within an expected base directory or match an allowlist before calling `readFileSync`.
+
+---
+
+## VUL-03 — HIGH: Integer Overflow in Pixel Position (Bitshift)
+
+**File:** `src/fillImageSizeDifference.ts:21`
+**CWE:** CWE-190 (Integer Overflow), CWE-787 (Out-of-bounds Write)
+
+### Description
+
+The pixel position is calculated using a bitwise left-shift `<< 2` (equivalent to `* 4`). In JavaScript, bitwise operators convert their operands to **32-bit signed integers** before operating. For large images, the intermediate value `image.width * y + x` can exceed `2^31 - 1 = 2,147,483,647`, causing the 32-bit conversion to produce a **negative or truncated value** before the shift, resulting in writing pixels to incorrect — potentially earlier — buffer offsets.
+
+### Vulnerable Code
+
+```ts
+// fillImageSizeDifference.ts:21
+drawPixelOnBuff(image.data, (image.width * y + x) << 2, color);
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^ overflows for large images
+```
+
+### Overflow Trigger
+
+For `width = 50000`, `y = 43001`, `x = 0`:
+
+```
+50000 * 43001 = 2,150,050,000  >  2^31 = 2,147,483,648
+ToInt32(2,150,050,000) = -2,144,917,296  (negative!)
+-2,144,917,296 << 2 = wraps to a small/wrong positive or negative value
+```
+
+### Impact
+
+- Pixels are written to **wrong buffer positions**, corrupting earlier pixel data in the image.
+- The diff output for large images will contain incorrect color data, making security-relevant visual comparisons unreliable.
+- Could mask actual pixel differences — a comparison tool returning incorrect results is a **security bypass** in visual regression testing pipelines.
+
+### Remediation
+
+Replace the bitshift with explicit multiplication to avoid the 32-bit conversion:
+
+```ts
+drawPixelOnBuff(image.data, (image.width * y + x) * 4, color);
+```
+
+---
+
+## VUL-04 — HIGH: Denial of Service via Crafted PNG Dimensions
+
+**File:** `src/comparePng.ts:68-71`, `src/extendImage.ts:19`
+**CWE:** CWE-400 (Uncontrolled Resource Consumption)
+
+### Description
+
+The `maxWidth` and `maxHeight` are derived directly from PNG header values parsed from input files, with no upper-bound check. A crafted PNG with inflated dimensions (e.g., 65535×65535) causes the library to allocate `65535 * 65535 * 4 ≈ 17 GB` of memory. This crashes or freezes the Node.js process.
+
+### Vulnerable Code
+
+```ts
+// comparePng.ts:68-71
+const maxWidth: number = Math.max(width1, width2);
+const maxHeight: number = Math.max(height1, height2);
+const diff: PNG = new PNG({ width: maxWidth, height: maxHeight }); // no size cap
+
+// extendImage.ts:19
+const extendedImage = new PNG({ width: newWidth, height: newHeight, fill: true }); // allocates ~17GB
+```
+
+### Proof of Concept
+
+A PNG file with header declaring `width=65535, height=65535` but minimal compressed data can be created in a few bytes (PNG supports empty/zeroed IDAT chunks). Passing such a file to `comparePng` triggers a fatal memory allocation.
+
+### Impact
+
+- **Process crash** / out-of-memory kill for any service that exposes `comparePng` to external input.
+- Even moderate abuse (e.g., 16000×16000 = ~1 GB per image) can exhaust memory and degrade performance.
+
+### Remediation
+
+Add dimension guards before allocation:
+
+```ts
+const MAX_DIMENSION = 8192; // or a configurable limit
+if (maxWidth > MAX_DIMENSION || maxHeight > MAX_DIMENSION) {
+    throw new Error(`Image dimensions exceed maximum allowed size (${MAX_DIMENSION}px)`);
+}
+```
+
+---
+
+## VUL-05 — MEDIUM: Filesystem Enumeration via Error Message Differentiation
+
+**File:** `src/getPngData.ts:24-31`
+**CWE:** CWE-209 (Information Exposure Through an Error Message)
+
+### Description
+
+Two structurally different error messages are produced depending on whether a file **does not exist** vs. **exists but is not a valid PNG**. This allows callers to probe the existence of arbitrary files on the filesystem by observing error message content.
+
+### Vulnerable Code
+
+```ts
+// getPngData.ts:24-28 — file-system level error (file doesn't exist, permission denied, etc.)
+throw new Error(`PNG file ${pngSource} could not be read: ${message}`);
+
+// getPngData.ts:13-14 — PNG parse error (file exists but isn't a PNG)
+throw new Error(`${source} could not be read: ${message}`);
+```
+
+The OS-level `message` differs: `ENOENT: no such file or directory` vs. `Invalid PNG signature`.
+
+### Proof of Concept
+
+```ts
+try {
+    comparePng('/etc/shadow', validPng);
+} catch (e) {
+    if (e.message.includes('ENOENT')) console.log('File does not exist');
+    if (e.message.includes('Invalid PNG')) console.log('File EXISTS (not a PNG)');
+    if (e.message.includes('EACCES')) console.log('File exists but not readable');
+}
+```
+
+### Impact
+
+- Enables **arbitrary filesystem enumeration** — determining which files/directories exist on the server.
+- Sensitive paths (`.env`, private keys, shadow files) can be probed.
+
+### Remediation
+
+Normalize error messages to remove OS-specific details:
+
+```ts
+throw new Error(`Invalid PNG input: source could not be parsed`);
+```
+
+---
+
+## VUL-06 — MEDIUM: No Runtime Validation of Color Channel Values
+
+**File:** `src/drawPixelOnBuff.ts:12-15`, `src/types/color.ts`
+**CWE:** CWE-20 (Improper Input Validation)
+
+### Description
+
+The `Color` type enforces channel ranges (0–255) only at TypeScript compile time. At runtime — especially when the library is consumed from plain JavaScript — `NaN`, negative values, or values > 255 are silently truncated by JavaScript's `Buffer` byte-assignment semantics (`buf[i] = val` is treated as `val & 0xFF` after `ToUint8`).
+
+### Vulnerable Code
+
+```ts
+// drawPixelOnBuff.ts
+buff[position + 0] = color.r; // NaN → 0, -1 → 255, 256 → 0 (silent)
+buff[position + 1] = color.g;
+buff[position + 2] = color.b;
+buff[position + 3] = 255;
+```
+
+### Impact
+
+- **Bypassed exclusion logic**: If `excludedAreaColor` is crafted with `NaN` values, all channels write as `0` instead of the intended color. Both images still match (both write the same invalid color), but any tooling expecting a specific exclusion color (e.g., screenshot inspection) will be silently wrong.
+- **Silent data corruption**: Extended-area fills with invalid colors produce unexpected visual output without any error signal.
+
+### Remediation
+
+Validate color channels at the boundary where options are accepted:
+
+```ts
+function validateColor(color: Color, name: string): void {
+    for (const [ch, val] of Object.entries(color)) {
+        if (!Number.isInteger(val) || val < 0 || val > 255) {
+            throw new RangeError(`${name}.${ch} must be an integer in [0, 255], got ${val}`);
+        }
+    }
+}
+```
+
+---
+
+## VUL-07 — LOW: Duplicate `URL.revokeObjectURL` Call
+
+**File:** `tools/excluded-areas-builder.html:391-392`
+**CWE:** CWE-672 (Operation on a Resource after Expiration or Release)
+
+### Description
+
+`URL.revokeObjectURL(url)` is called twice in immediate succession. After the first call, the object URL is invalid; the second call is a no-op in modern browsers but indicates a code defect.
+
+```js
+URL.revokeObjectURL(url); // line 391
+URL.revokeObjectURL(url); // line 392 — duplicate, dead code
+```
+
+### Impact
+
+Low — browsers silently ignore the second revocation. No security impact in current browsers, but could cause issues in strict/non-standard environments.
+
+---
+
+## VUL-08 — LOW: Missing Content-Security-Policy in Developer Tool
+
+**File:** `tools/excluded-areas-builder.html`
+**CWE:** CWE-1021 (Improper Restriction of Rendered UI Layers or Frames)
+
+### Description
+
+The HTML tool contains no `Content-Security-Policy` (CSP) meta tag. The page uses inline `<script>` and inline `<style>` blocks extensively. Without a CSP, any XSS vector (e.g., malicious SVG content from an uploaded image processed through `innerHTML`) would execute without restriction.
+
+### Specific Risk
+
+In `renderSidebar()` (line 608-610), `innerHTML` is used to compose HTML from area coordinate data:
+
+```js
+info.innerHTML =
+    `<strong style="color:#ccc">#${idx + 1}</strong>` +
+    ` <span class="area-coords">(${area.x1},${area.y1}) → (${area.x2},${area.y2})</span>`;
+```
+
+The coordinate values (`area.x1` etc.) originate from mouse events (integers, safe in this flow), but any future code path that accepts area data from an external source (e.g., URL parameters, pasted JSON) without sanitization would be vulnerable to XSS here.
+
+### Impact
+
+Currently low (local developer tool, coordinates come from mouse events). Becomes HIGH if the tool is ever served over HTTP or extended to accept externally-sourced area data.
+
+### Remediation
+
+Add CSP and replace `innerHTML` with safe DOM construction using `textContent`:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self';" />
+```
+
+---
+
+## Attack Chains
+
+### Chain 1: Remote Code Execution (Server Context)
+
+If `comparePng` is exposed via a web API that accepts user-controlled `png1`/`png2`/`diffFilePath`:
+
+1. **VUL-02**: Read any file via path traversal in `png1`/`png2` → enumerate filesystem.
+2. **VUL-05**: Use error message differences to identify sensitive files.
+3. **VUL-01**: Write a PNG-format payload to a cron directory or web root → **RCE**.
+
+### Chain 2: Visual Regression Bypass (CI/CD Context)
+
+In an automated visual testing pipeline:
+
+1. **VUL-03**: Craft a very large PNG → trigger integer overflow → pixel data is written to wrong buffer position.
+2. The diff buffer now contains corrupted data, and `pixelmatch` compares incorrect pixel values.
+3. A **real visual difference is masked** — `comparePng` returns 0 mismatches for images that actually differ.
+4. Malicious UI changes pass visual regression gates undetected.
+
+---
+
+## Recommendations Summary
+
+| Priority  | Action                                                                   |
+| --------- | ------------------------------------------------------------------------ |
+| Immediate | Validate and restrict `diffFilePath` to a safe output directory (VUL-01) |
+| Immediate | Validate and restrict file path inputs `png1`/`png2` (VUL-02)            |
+| High      | Replace `<< 2` with `* 4` for pixel position calculation (VUL-03)        |
+| High      | Add maximum dimension guards before PNG buffer allocation (VUL-04)       |
+| Medium    | Normalize error messages to prevent filesystem enumeration (VUL-05)      |
+| Medium    | Add runtime validation for Color channel values (VUL-06)                 |
+| Low       | Remove duplicate `revokeObjectURL` call (VUL-07)                         |
+| Low       | Add CSP header and replace `innerHTML` with safe DOM APIs (VUL-08)       |

--- a/__tests__/comparePng.exceptions.test.ts
+++ b/__tests__/comparePng.exceptions.test.ts
@@ -91,22 +91,80 @@ for (const testData of testDataArrayInvalidBoth) {
     });
 }
 
-// ── VUL-01: diffFilePath null byte injection ──────────────────────────────────
+// ── Option validation tests (data-driven, consistent with repo conventions) ───
 const validPng = resolve('./test-data/actual/youtube-play-button.png');
 
-test('should throw when diffFilePath contains a null byte', () => {
-    expect(() => comparePng(validPng, validPng, { diffFilePath: '/tmp/diff\0.png' })).toThrow('null bytes');
-});
+const testDataArrayOptionValidation: {
+    id: number;
+    name: string;
+    opts: Parameters<typeof comparePng>[2];
+    throws: true | false;
+    errorPattern?: string | RegExp;
+}[] = [
+    {
+        id: 1,
+        name: 'diffFilePath with null byte (VUL-01)',
+        opts: { diffFilePath: 'diff\0.png' },
+        throws: true,
+        errorPattern: 'null bytes',
+    },
+    {
+        id: 2,
+        name: 'diffFilePath non-string value',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        opts: { diffFilePath: 42 as any },
+        throws: true,
+        errorPattern: 'diffFilePath must be a string',
+    },
+    {
+        id: 3,
+        name: 'maxDimension too small for 920x512 test image (VUL-04)',
+        opts: { maxDimension: 100 },
+        throws: true,
+        errorPattern: 'exceed the maximum allowed size',
+    },
+    {
+        id: 4,
+        name: 'maxDimension NaN is rejected',
+        opts: { maxDimension: NaN },
+        throws: true,
+        errorPattern: 'maxDimension must be a positive integer or Infinity',
+    },
+    {
+        id: 5,
+        name: 'maxDimension negative integer is rejected',
+        opts: { maxDimension: -1 },
+        throws: true,
+        errorPattern: 'maxDimension must be a positive integer or Infinity',
+    },
+    {
+        id: 6,
+        name: 'maxDimension set high enough for test images (1024)',
+        opts: { maxDimension: 1024 },
+        throws: false,
+    },
+    {
+        id: 7,
+        name: 'maxDimension Infinity disables the limit',
+        opts: { maxDimension: Infinity },
+        throws: false,
+    },
+    {
+        id: 8,
+        name: 'default options accept normal test images',
+        opts: {},
+        throws: false,
+    },
+];
 
-// ── VUL-04: dimension limit ───────────────────────────────────────────────────
-test('should throw when image exceeds default maxDimension (920x512 image, limit 100)', () => {
-    expect(() => comparePng(validPng, validPng, { maxDimension: 100 })).toThrow('exceed the maximum allowed size');
-});
-
-test('should not throw when maxDimension is set high enough for the test images', () => {
-    expect(() => comparePng(validPng, validPng, { maxDimension: 1024 })).not.toThrow();
-});
-
-test('should not throw with default maxDimension for normal test images', () => {
-    expect(() => comparePng(validPng, validPng)).not.toThrow();
-});
+for (const testData of testDataArrayOptionValidation) {
+    if (testData.throws) {
+        test(`should throw for option validation: ${testData.name}`, () => {
+            expect(() => comparePng(validPng, validPng, testData.opts)).toThrow(testData.errorPattern ?? Error);
+        });
+    } else {
+        test(`should not throw for option validation: ${testData.name}`, () => {
+            expect(() => comparePng(validPng, validPng, testData.opts)).not.toThrow();
+        });
+    }
+}

--- a/__tests__/comparePng.exceptions.test.ts
+++ b/__tests__/comparePng.exceptions.test.ts
@@ -155,6 +155,39 @@ const testDataArrayOptionValidation: {
         opts: {},
         throws: false,
     },
+    {
+        id: 9,
+        name: 'diffFilePath traverses above diffOutputBaseDir (VUL-01)',
+        opts: {
+            diffFilePath: resolve('./test-data/actual/../../../etc/passwd'),
+            diffOutputBaseDir: resolve('./test-data/actual'),
+        },
+        throws: true,
+        errorPattern: 'Path traversal detected',
+    },
+    {
+        id: 10,
+        name: 'diffFilePath inside diffOutputBaseDir is accepted',
+        // No actual diff written (images are identical), so just checking it does not throw.
+        opts: {
+            diffFilePath: resolve('./test-data/actual/diff.png'),
+            diffOutputBaseDir: resolve('./test-data/actual'),
+        },
+        throws: false,
+    },
+    {
+        id: 11,
+        name: 'inputBaseDir rejects png1 path outside allowed directory (VUL-02)',
+        opts: { inputBaseDir: resolve('./test-data/expected') },
+        throws: true,
+        errorPattern: 'Path traversal detected',
+    },
+    {
+        id: 12,
+        name: 'inputBaseDir accepts png paths inside allowed directory',
+        opts: { inputBaseDir: resolve('./test-data/actual') },
+        throws: false,
+    },
 ];
 
 for (const testData of testDataArrayOptionValidation) {

--- a/__tests__/comparePng.exceptions.test.ts
+++ b/__tests__/comparePng.exceptions.test.ts
@@ -90,3 +90,23 @@ for (const testData of testDataArrayInvalidBoth) {
         ).toThrow(Error);
     });
 }
+
+// ── VUL-01: diffFilePath null byte injection ──────────────────────────────────
+const validPng = resolve('./test-data/actual/youtube-play-button.png');
+
+test('should throw when diffFilePath contains a null byte', () => {
+    expect(() => comparePng(validPng, validPng, { diffFilePath: '/tmp/diff\0.png' })).toThrow('null bytes');
+});
+
+// ── VUL-04: dimension limit ───────────────────────────────────────────────────
+test('should throw when image exceeds default maxDimension (920x512 image, limit 100)', () => {
+    expect(() => comparePng(validPng, validPng, { maxDimension: 100 })).toThrow('exceed the maximum allowed size');
+});
+
+test('should not throw when maxDimension is set high enough for the test images', () => {
+    expect(() => comparePng(validPng, validPng, { maxDimension: 1024 })).not.toThrow();
+});
+
+test('should not throw with default maxDimension for normal test images', () => {
+    expect(() => comparePng(validPng, validPng)).not.toThrow();
+});

--- a/__tests__/getPngData.non-error.test.ts
+++ b/__tests__/getPngData.non-error.test.ts
@@ -15,12 +15,12 @@ it('should throw with fallback error detail when the caught value is not an Erro
     vi.spyOn(nodeFs, 'readFileSync').mockImplementationOnce(() => {
         throw 'non-error string';
     });
-    expect(() => getPngData('/any/path.png', true)).toThrow(/^PNG file .+ could not be read: Unknown error$/);
+    expect(() => getPngData('/any/path.png', true)).toThrow('Invalid PNG input: the file could not be read');
 });
 
 it('should throw with fallback error detail when PNG parsing throws a non-Error value', () => {
     vi.spyOn(PNG.sync, 'read').mockImplementationOnce(() => {
         throw 'non-error string';
     });
-    expect(() => getPngData(Buffer.from('not-a-real-png'), true)).toThrow(/^PNG buffer could not be read: Unknown error$/);
+    expect(() => getPngData(Buffer.from('not-a-real-png'), true)).toThrow('Invalid PNG input: the data could not be parsed');
 });

--- a/__tests__/getPngData.non-error.test.ts
+++ b/__tests__/getPngData.non-error.test.ts
@@ -15,7 +15,7 @@ it('should throw with fallback error detail when the caught value is not an Erro
     vi.spyOn(nodeFs, 'readFileSync').mockImplementationOnce(() => {
         throw 'non-error string';
     });
-    expect(() => getPngData('/any/path.png', true)).toThrow('Invalid PNG input: the file could not be read');
+    expect(() => getPngData('/any/path.png', true)).toThrow('Invalid PNG input: the source could not be loaded');
 });
 
 it('should throw with fallback error detail when PNG parsing throws a non-Error value', () => {
@@ -23,4 +23,48 @@ it('should throw with fallback error detail when PNG parsing throws a non-Error 
         throw 'non-error string';
     });
     expect(() => getPngData(Buffer.from('not-a-real-png'), true)).toThrow('Invalid PNG input: the data could not be parsed');
+});
+
+// Cover the string-path parse-failure branch (file exists but is not a valid PNG).
+// readFileSync is left real; only PNG.sync.read is mocked to simulate a corrupt file.
+it('should throw the unified message when a string-path file exists but PNG parse fails (throwError=true)', () => {
+    vi.spyOn(nodeFs, 'readFileSync').mockImplementationOnce(() => Buffer.from('fake png bytes'));
+    vi.spyOn(PNG.sync, 'read').mockImplementationOnce(() => {
+        throw new Error('Invalid PNG signature');
+    });
+    expect(() => getPngData('/any/valid-path.png', true)).toThrow('Invalid PNG input: the source could not be loaded');
+});
+
+it('should return invalidPng when a string-path file exists but PNG parse fails (throwError=false)', () => {
+    vi.spyOn(nodeFs, 'readFileSync').mockImplementationOnce(() => Buffer.from('fake png bytes'));
+    vi.spyOn(PNG.sync, 'read').mockImplementationOnce(() => {
+        throw new Error('Invalid PNG signature');
+    });
+    const result = getPngData('/any/valid-path.png', false);
+    expect(result.isValid).toBe(false);
+    expect(result.png.width).toBe(0);
+    expect(result.png.height).toBe(0);
+});
+
+// Cover peekPngDimensions return-null branches (lines 21-22 of getPngData.ts).
+// assertDimensions is only invoked when maxDimension is passed; inside it,
+// peekPngDimensions returns null for the two cases below, so no dimension
+// error is thrown and execution falls through to PNG.sync.read.
+
+it('should not throw a dimension error when the buffer is shorter than 24 bytes (peekPngDimensions line 21)', () => {
+    // 10-byte buffer — too short to contain a full IHDR, so peekPngDimensions returns null.
+    const shortBuffer = Buffer.alloc(10);
+    vi.spyOn(PNG.sync, 'read').mockImplementationOnce(() => {
+        throw new Error('not a png');
+    });
+    expect(() => getPngData(shortBuffer, true, 100)).toThrow('Invalid PNG input: the data could not be parsed');
+});
+
+it('should not throw a dimension error when the buffer has an invalid PNG signature (peekPngDimensions line 22)', () => {
+    // 24-byte buffer of zeros — long enough for an IHDR peek but the signature is wrong.
+    const wrongSigBuffer = Buffer.alloc(24, 0);
+    vi.spyOn(PNG.sync, 'read').mockImplementationOnce(() => {
+        throw new Error('not a png');
+    });
+    expect(() => getPngData(wrongSigBuffer, true, 100)).toThrow('Invalid PNG input: the data could not be parsed');
 });

--- a/__tests__/getPngData.test.ts
+++ b/__tests__/getPngData.test.ts
@@ -17,7 +17,9 @@ describe('getPngData', () => {
     });
 
     it('should throw an error for an invalid PNG file path when throwErrorOnInvalidInputData is true', () => {
-        expect(() => getPngData(invalidPngPath, true)).toThrow('Invalid PNG input: the file could not be read');
+        // Both "file not found" and "file exists but not a PNG" produce the same
+        // message so callers cannot enumerate the filesystem (VUL-05).
+        expect(() => getPngData(invalidPngPath, true)).toThrow('Invalid PNG input: the source could not be loaded');
     });
 
     it('should return invalid PngData for an invalid PNG file path when throwErrorOnInvalidInputData is false', () => {

--- a/__tests__/getPngData.test.ts
+++ b/__tests__/getPngData.test.ts
@@ -17,7 +17,7 @@ describe('getPngData', () => {
     });
 
     it('should throw an error for an invalid PNG file path when throwErrorOnInvalidInputData is true', () => {
-        expect(() => getPngData(invalidPngPath, true)).toThrow(new RegExp(`PNG file .+ could not be read: .+`));
+        expect(() => getPngData(invalidPngPath, true)).toThrow('Invalid PNG input: the file could not be read');
     });
 
     it('should return invalid PngData for an invalid PNG file path when throwErrorOnInvalidInputData is false', () => {
@@ -43,7 +43,18 @@ describe('getPngData', () => {
     });
 
     it('should throw an error for an invalid PNG buffer when throwErrorOnInvalidInputData is true', () => {
-        expect(() => getPngData(invalidPngBuffer, true)).toThrow(/^PNG buffer could not be read: .+$/);
+        expect(() => getPngData(invalidPngBuffer, true)).toThrow('Invalid PNG input: the data could not be parsed');
+    });
+
+    it('should throw an error for a path containing a null byte when throwErrorOnInvalidInputData is true', () => {
+        expect(() => getPngData('/tmp/evil\0.png', true)).toThrow('null bytes');
+    });
+
+    it('should return invalid PngData for a path containing a null byte when throwErrorOnInvalidInputData is false', () => {
+        const result = getPngData('/tmp/evil\0.png', false);
+        expect(result.isValid).toBe(false);
+        expect(result.png.width).toBe(0);
+        expect(result.png.height).toBe(0);
     });
 
     it('should throw an error for an unknown input type when throwErrorOnInvalidInputData is true', () => {

--- a/__tests__/validateColor.test.ts
+++ b/__tests__/validateColor.test.ts
@@ -42,6 +42,13 @@ describe('validateColor', () => {
     it('error message includes the channel name and value', () => {
         expect(() => validateColor({ r: 300, g: 0, b: 0 }, 'testColor')).toThrow('testColor.r must be an integer in [0, 255], got 300');
     });
+
+    it('should throw RangeError for a missing channel (e.g. b omitted)', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(() => validateColor({ r: 0, g: 0 } as any, 'color')).toThrow(RangeError);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(() => validateColor({ r: 0, g: 0 } as any, 'color')).toThrow('color.b');
+    });
 });
 
 // Integration: comparePng should surface color validation errors

--- a/__tests__/validateColor.test.ts
+++ b/__tests__/validateColor.test.ts
@@ -1,0 +1,63 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { comparePng } from '../src';
+import { validateColor } from '../src/validateColor';
+
+describe('validateColor', () => {
+    it('should not throw for a valid color', () => {
+        expect(() => validateColor({ r: 0, g: 128, b: 255 }, 'color')).not.toThrow();
+    });
+
+    it('should not throw for all-zero color', () => {
+        expect(() => validateColor({ r: 0, g: 0, b: 0 }, 'color')).not.toThrow();
+    });
+
+    it('should not throw for max-value color', () => {
+        expect(() => validateColor({ r: 255, g: 255, b: 255 }, 'color')).not.toThrow();
+    });
+
+    it('should throw RangeError for NaN channel', () => {
+        expect(() => validateColor({ r: NaN, g: 0, b: 0 }, 'extendedAreaColor')).toThrow(RangeError);
+        expect(() => validateColor({ r: NaN, g: 0, b: 0 }, 'extendedAreaColor')).toThrow('extendedAreaColor.r');
+    });
+
+    it('should throw RangeError for negative channel', () => {
+        expect(() => validateColor({ r: 0, g: -1, b: 0 }, 'myColor')).toThrow(RangeError);
+        expect(() => validateColor({ r: 0, g: -1, b: 0 }, 'myColor')).toThrow('myColor.g');
+    });
+
+    it('should throw RangeError for channel > 255', () => {
+        expect(() => validateColor({ r: 0, g: 0, b: 256 }, 'color')).toThrow(RangeError);
+        expect(() => validateColor({ r: 0, g: 0, b: 256 }, 'color')).toThrow('color.b');
+    });
+
+    it('should throw RangeError for a float channel', () => {
+        expect(() => validateColor({ r: 1.5, g: 0, b: 0 }, 'color')).toThrow(RangeError);
+    });
+
+    it('should throw RangeError for Infinity', () => {
+        expect(() => validateColor({ r: Infinity, g: 0, b: 0 }, 'color')).toThrow(RangeError);
+    });
+
+    it('error message includes the channel name and value', () => {
+        expect(() => validateColor({ r: 300, g: 0, b: 0 }, 'testColor')).toThrow('testColor.r must be an integer in [0, 255], got 300');
+    });
+});
+
+// Integration: comparePng should surface color validation errors
+describe('comparePng color validation integration', () => {
+    const validPng = resolve('./test-data/actual/youtube-play-button.png');
+
+    it('should throw RangeError when extendedAreaColor has a NaN channel', () => {
+        expect(() => comparePng(validPng, validPng, { extendedAreaColor: { r: NaN, g: 0, b: 0 } })).toThrow(RangeError);
+    });
+
+    it('should throw RangeError when excludedAreaColor has a channel > 255', () => {
+        expect(() =>
+            comparePng(validPng, validPng, {
+                excludedAreaColor: { r: 0, g: 0, b: 256 },
+                excludedAreas: [{ x1: 0, y1: 0, x2: 10, y2: 10 }],
+            }),
+        ).toThrow(RangeError);
+    });
+});

--- a/__tests__/validatePath.test.ts
+++ b/__tests__/validatePath.test.ts
@@ -10,7 +10,9 @@ describe('validatePath', () => {
     });
 
     it('should return an absolute path unchanged (after resolve)', () => {
-        const abs = '/tmp/output/diff.png';
+        // Construct a guaranteed-absolute path using path.resolve so the test is
+        // platform-independent (avoids Unix-only /tmp/ prefix on Windows).
+        const abs = path.resolve('some', 'output', 'diff.png');
         expect(validatePath(abs)).toBe(abs);
     });
 

--- a/__tests__/validatePath.test.ts
+++ b/__tests__/validatePath.test.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { validatePath } from '../src/validatePath';
+
+describe('validatePath', () => {
+    it('should resolve a relative path to an absolute path', () => {
+        const result = validatePath('./some/file.png');
+        expect(path.isAbsolute(result)).toBe(true);
+        expect(result).toBe(path.resolve('./some/file.png'));
+    });
+
+    it('should return an absolute path unchanged (after resolve)', () => {
+        const abs = '/tmp/output/diff.png';
+        expect(validatePath(abs)).toBe(abs);
+    });
+
+    it('should throw an Error when the path contains a null byte', () => {
+        expect(() => validatePath('/tmp/evil\0.png')).toThrow(Error);
+        expect(() => validatePath('/tmp/evil\0.png')).toThrow('null bytes');
+    });
+
+    it('should throw when null byte appears mid-path', () => {
+        expect(() => validatePath('relative\0/path.png')).toThrow(Error);
+    });
+
+    it('should accept paths with dot-dot segments (resolution is caller responsibility)', () => {
+        const result = validatePath('../some/file.png');
+        expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should accept an empty string and return the resolved CWD', () => {
+        const result = validatePath('');
+        expect(path.isAbsolute(result)).toBe(true);
+    });
+});

--- a/__tests__/validatePath.test.ts
+++ b/__tests__/validatePath.test.ts
@@ -38,3 +38,38 @@ describe('validatePath', () => {
         expect(() => validatePath('   ')).toThrow('empty or whitespace only');
     });
 });
+
+describe('validatePath — baseDir containment (VUL-01, VUL-02)', () => {
+    const baseDir = path.resolve('test-output');
+
+    it('should accept a path that resolves inside baseDir', () => {
+        const filePath = path.join(baseDir, 'diff.png');
+        expect(validatePath(filePath, baseDir)).toBe(filePath);
+    });
+
+    it('should accept a path equal to baseDir itself', () => {
+        expect(validatePath(baseDir, baseDir)).toBe(baseDir);
+    });
+
+    it('should throw when path traverses above baseDir via dot-dot', () => {
+        const traversal = path.join(baseDir, '..', 'etc', 'passwd');
+        expect(() => validatePath(traversal, baseDir)).toThrow('Path traversal detected');
+    });
+
+    it('should throw when an absolute path outside baseDir is given', () => {
+        const outside = path.resolve('other-dir', 'file.png');
+        expect(() => validatePath(outside, baseDir)).toThrow('Path traversal detected');
+    });
+
+    it('should reject a path that shares baseDir as a prefix but is a sibling (prefix collision)', () => {
+        // e.g. baseDir = /foo/bar, path = /foo/bar-evil/file.png
+        // Without the sep check, startsWith would incorrectly allow this.
+        const sibling = baseDir + '-evil' + path.sep + 'file.png';
+        expect(() => validatePath(sibling, baseDir)).toThrow('Path traversal detected');
+    });
+
+    it('should not throw when baseDir is undefined (no containment enforced)', () => {
+        const anyPath = path.resolve('anywhere', 'file.png');
+        expect(() => validatePath(anyPath, undefined)).not.toThrow();
+    });
+});

--- a/__tests__/validatePath.test.ts
+++ b/__tests__/validatePath.test.ts
@@ -30,8 +30,11 @@ describe('validatePath', () => {
         expect(path.isAbsolute(result)).toBe(true);
     });
 
-    it('should accept an empty string and return the resolved CWD', () => {
-        const result = validatePath('');
-        expect(path.isAbsolute(result)).toBe(true);
+    it('should throw for an empty string', () => {
+        expect(() => validatePath('')).toThrow('empty or whitespace only');
+    });
+
+    it('should throw for a whitespace-only string', () => {
+        expect(() => validatePath('   ')).toThrow('empty or whitespace only');
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
     "name": "png-visual-compare",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "png-visual-compare",
-            "version": "4.1.0",
+            "version": "5.0.0",
             "license": "MIT",
             "dependencies": {
                 "pixelmatch": "~7.1.0",
                 "pngjs": "~7.0.0"
             },
             "devDependencies": {
-                "@playwright/test": "~1.58.2",
+                "@playwright/test": "~1.59.1",
                 "@types/node": "~25.5.0",
                 "@types/pngjs": "~6.0.5",
-                "@vitest/coverage-v8": "~4.1.1",
+                "@vitest/coverage-v8": "~4.1.2",
                 "eslint": "~10.1.0",
                 "prettier": "~3.8.1",
                 "rimraf": "~6.1.3",
-                "typescript": "~5.9.3",
-                "typescript-eslint": "~8.57.2",
-                "vitest": "~4.1.1"
+                "typescript": "~6.0.2",
+                "typescript-eslint": "~8.58.0",
+                "vitest": "~4.1.2"
             },
             "engines": {
                 "node": ">=20"
@@ -99,6 +99,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.0",
                 "tslib": "^2.4.0"
@@ -111,6 +112,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -122,6 +124,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -314,20 +317,22 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
                 "@tybys/wasm-util": "^0.10.1"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@oxc-project/types": {
@@ -341,13 +346,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-            "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.58.2"
+                "playwright": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -357,9 +362,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
-            "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
             "cpu": [
                 "arm64"
             ],
@@ -374,9 +379,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
-            "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
             "cpu": [
                 "arm64"
             ],
@@ -391,9 +396,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
-            "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
             "cpu": [
                 "x64"
             ],
@@ -408,9 +413,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
-            "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
             "cpu": [
                 "x64"
             ],
@@ -425,9 +430,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
-            "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
             "cpu": [
                 "arm"
             ],
@@ -442,9 +447,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
-            "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
             "cpu": [
                 "arm64"
             ],
@@ -462,9 +467,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
-            "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
             "cpu": [
                 "arm64"
             ],
@@ -482,9 +487,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
-            "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
             "cpu": [
                 "ppc64"
             ],
@@ -502,9 +507,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
-            "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
                 "s390x"
             ],
@@ -522,9 +527,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
-            "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
             "cpu": [
                 "x64"
             ],
@@ -542,9 +547,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
-            "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
             "cpu": [
                 "x64"
             ],
@@ -562,9 +567,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
-            "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
             "cpu": [
                 "arm64"
             ],
@@ -579,9 +584,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
-            "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
             "cpu": [
                 "wasm32"
             ],
@@ -596,9 +601,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
-            "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -613,9 +618,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
-            "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +635,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
-            "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
             "dev": true,
             "license": "MIT"
         },
@@ -714,20 +719,20 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-            "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+            "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/type-utils": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/type-utils": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -737,9 +742,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.2",
+                "@typescript-eslint/parser": "^8.58.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -753,16 +758,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-            "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+            "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -774,18 +779,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-            "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+            "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.2",
-                "@typescript-eslint/types": "^8.57.2",
+                "@typescript-eslint/tsconfig-utils": "^8.58.0",
+                "@typescript-eslint/types": "^8.58.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -796,18 +801,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-            "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+            "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2"
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -818,9 +823,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-            "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+            "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -831,21 +836,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-            "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+            "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -856,13 +861,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-            "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+            "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -874,21 +879,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-            "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+            "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.2",
-                "@typescript-eslint/tsconfig-utils": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/project-service": "8.58.0",
+                "@typescript-eslint/tsconfig-utils": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -898,20 +903,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-            "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+            "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2"
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -922,17 +927,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-            "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+            "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
+                "@typescript-eslint/types": "8.58.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -944,14 +949,14 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.1.tgz",
-            "integrity": "sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+            "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.1",
+                "@vitest/utils": "4.1.2",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -959,14 +964,14 @@
                 "magicast": "^0.5.2",
                 "obug": "^2.1.1",
                 "std-env": "^4.0.0-rc.1",
-                "tinyrainbow": "^3.0.3"
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.1",
-                "vitest": "4.1.1"
+                "@vitest/browser": "4.1.2",
+                "vitest": "4.1.2"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -975,31 +980,31 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
-            "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+            "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.1",
-                "@vitest/utils": "4.1.1",
+                "@vitest/spy": "4.1.2",
+                "@vitest/utils": "4.1.2",
                 "chai": "^6.2.2",
-                "tinyrainbow": "^3.0.3"
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
-            "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+            "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.1",
+                "@vitest/spy": "4.1.2",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1020,26 +1025,26 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
-            "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+            "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^3.0.3"
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
-            "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+            "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.1",
+                "@vitest/utils": "4.1.2",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1047,14 +1052,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
-            "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+            "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.1",
-                "@vitest/utils": "4.1.1",
+                "@vitest/pretty-format": "4.1.2",
+                "@vitest/utils": "4.1.2",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1063,9 +1068,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
-            "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+            "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1073,15 +1078,15 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
-            "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+            "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.1",
+                "@vitest/pretty-format": "4.1.2",
                 "convert-source-map": "^2.0.0",
-                "tinyrainbow": "^3.0.3"
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -1160,9 +1165,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2063,13 +2068,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -2266,13 +2271,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.2"
+                "playwright-core": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -2285,9 +2290,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2392,14 +2397,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.11",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
-            "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@oxc-project/types": "=0.122.0",
-                "@rolldown/pluginutils": "1.0.0-rc.11"
+                "@rolldown/pluginutils": "1.0.0-rc.12"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -2408,21 +2413,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.11",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
             }
         },
         "node_modules/semver": {
@@ -2584,9 +2589,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2598,16 +2603,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
-            "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+            "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.2",
-                "@typescript-eslint/parser": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2"
+                "@typescript-eslint/eslint-plugin": "8.58.0",
+                "@typescript-eslint/parser": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2618,7 +2623,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/undici-types": {
@@ -2639,16 +2644,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
-            "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+            "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.11",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -2732,19 +2737,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
-            "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+            "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.1",
-                "@vitest/mocker": "4.1.1",
-                "@vitest/pretty-format": "4.1.1",
-                "@vitest/runner": "4.1.1",
-                "@vitest/snapshot": "4.1.1",
-                "@vitest/spy": "4.1.1",
-                "@vitest/utils": "4.1.1",
+                "@vitest/expect": "4.1.2",
+                "@vitest/mocker": "4.1.2",
+                "@vitest/pretty-format": "4.1.2",
+                "@vitest/runner": "4.1.2",
+                "@vitest/snapshot": "4.1.2",
+                "@vitest/spy": "4.1.2",
+                "@vitest/utils": "4.1.2",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -2755,7 +2760,7 @@
                 "tinybench": "^2.9.0",
                 "tinyexec": "^1.0.2",
                 "tinyglobby": "^0.2.15",
-                "tinyrainbow": "^3.0.3",
+                "tinyrainbow": "^3.1.0",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
                 "why-is-node-running": "^2.3.0"
             },
@@ -2772,10 +2777,10 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.1",
-                "@vitest/browser-preview": "4.1.1",
-                "@vitest/browser-webdriverio": "4.1.1",
-                "@vitest/ui": "4.1.1",
+                "@vitest/browser-playwright": "4.1.2",
+                "@vitest/browser-preview": "4.1.2",
+                "@vitest/browser-webdriverio": "4.1.2",
+                "@vitest/ui": "4.1.2",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "png-visual-compare",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "png-visual-compare",
-            "version": "5.0.0",
+            "version": "5.1.0",
             "license": "MIT",
             "dependencies": {
                 "pixelmatch": "~7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
             },
             "devDependencies": {
                 "@playwright/test": "~1.59.1",
-                "@types/node": "~25.5.0",
+                "@types/node": "~25.5.2",
                 "@types/pngjs": "~6.0.5",
                 "@vitest/coverage-v8": "~4.1.2",
-                "eslint": "~10.1.0",
+                "eslint": "~10.2.0",
                 "prettier": "~3.8.1",
                 "rimraf": "~6.1.3",
                 "typescript": "~6.0.2",
@@ -93,22 +93,22 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -118,9 +118,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -172,13 +172,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.23.3",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-            "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+            "version": "0.23.4",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
+            "integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^3.0.3",
+                "@eslint/object-schema": "^3.0.4",
                 "debug": "^4.3.1",
                 "minimatch": "^10.2.4"
             },
@@ -187,22 +187,22 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-            "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
+            "integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^1.1.1"
+                "@eslint/core": "^1.2.0"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-            "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.0.tgz",
+            "integrity": "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -213,9 +213,9 @@
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-            "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
+            "integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -223,13 +223,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-            "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
+            "integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^1.1.1",
+                "@eslint/core": "^1.2.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -699,9 +699,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-            "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+            "version": "25.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1265,18 +1265,18 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-            "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+            "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
-                "@eslint/config-array": "^0.23.3",
-                "@eslint/config-helpers": "^0.5.3",
-                "@eslint/core": "^1.1.1",
-                "@eslint/plugin-kit": "^0.6.1",
+                "@eslint/config-array": "^0.23.4",
+                "@eslint/config-helpers": "^0.5.4",
+                "@eslint/core": "^1.2.0",
+                "@eslint/plugin-kit": "^0.7.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "png-visual-compare",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "description": "Node.js utility to compare PNG files or their areas",
     "keywords": [
         "visual testing",
@@ -63,16 +63,16 @@
         "pngjs": "~7.0.0"
     },
     "devDependencies": {
-        "@playwright/test": "~1.58.2",
+        "@playwright/test": "~1.59.1",
         "@types/node": "~25.5.0",
         "@types/pngjs": "~6.0.5",
-        "@vitest/coverage-v8": "~4.1.1",
+        "@vitest/coverage-v8": "~4.1.2",
         "eslint": "~10.1.0",
         "prettier": "~3.8.1",
         "rimraf": "~6.1.3",
-        "typescript": "~5.9.3",
-        "typescript-eslint": "~8.57.2",
-        "vitest": "~4.1.1"
+        "typescript": "~6.0.2",
+        "typescript-eslint": "~8.58.0",
+        "vitest": "~4.1.2"
     },
     "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     },
     "devDependencies": {
         "@playwright/test": "~1.59.1",
-        "@types/node": "~25.5.0",
+        "@types/node": "~25.5.2",
         "@types/pngjs": "~6.0.5",
         "@vitest/coverage-v8": "~4.1.2",
-        "eslint": "~10.1.0",
+        "eslint": "~10.2.0",
         "prettier": "~3.8.1",
         "rimraf": "~6.1.3",
         "typescript": "~6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "png-visual-compare",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Node.js utility to compare PNG files or their areas",
     "keywords": [
         "visual testing",

--- a/src/comparePng.ts
+++ b/src/comparePng.ts
@@ -60,18 +60,32 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
     const throwErrorOnInvalidInputData: boolean = opts?.throwErrorOnInvalidInputData ?? true;
     const extendedAreaColor: Color = opts?.extendedAreaColor ?? DEFAULT_EXTENDED_AREA_COLOR;
     const excludedAreaColor: Color = opts?.excludedAreaColor ?? DEFAULT_EXCLUDED_AREA_COLOR;
-    const shouldCreateDiffFile: boolean = opts?.diffFilePath !== undefined;
-    // Validate diffFilePath eagerly (fail-fast) so injection is caught before any I/O
-    const validatedDiffFilePath: string | undefined = shouldCreateDiffFile ? validatePath(opts!.diffFilePath as string) : undefined;
-    const maxDimension: number = opts?.maxDimension ?? DEFAULT_MAX_DIMENSION;
+    // Resolve and validate diffFilePath eagerly (fail-fast) so injection is caught before any I/O
+    const rawDiffFilePath = opts?.diffFilePath;
+    let shouldCreateDiffFile = false;
+    let validatedDiffFilePath: string | undefined;
+    if (rawDiffFilePath !== undefined) {
+        if (typeof rawDiffFilePath !== 'string') {
+            throw new TypeError('opts.diffFilePath must be a string when provided');
+        }
+        shouldCreateDiffFile = true;
+        validatedDiffFilePath = validatePath(rawDiffFilePath);
+    }
+
+    // Validate maxDimension — must be a positive integer or Infinity
+    const rawMaxDimension = opts?.maxDimension ?? DEFAULT_MAX_DIMENSION;
+    if (rawMaxDimension !== Infinity && (!Number.isInteger(rawMaxDimension) || rawMaxDimension <= 0)) {
+        throw new TypeError('opts.maxDimension must be a positive integer or Infinity');
+    }
+    const maxDimension: number = rawMaxDimension;
 
     // Validate color options at the boundary before any pixel operations
     validateColor(extendedAreaColor, 'extendedAreaColor');
     validateColor(excludedAreaColor, 'excludedAreaColor');
 
-    // Get PNG data
-    const pngData1: PngData = getPngData(png1, throwErrorOnInvalidInputData);
-    const pngData2: PngData = getPngData(png2, throwErrorOnInvalidInputData);
+    // Get PNG data; maxDimension is checked inside getPngData before decoding (DoS guard)
+    const pngData1: PngData = getPngData(png1, throwErrorOnInvalidInputData, maxDimension);
+    const pngData2: PngData = getPngData(png2, throwErrorOnInvalidInputData, maxDimension);
 
     // Check if PNG data is valid
     if (!pngData1.isValid && !pngData2.isValid) {
@@ -83,13 +97,6 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
 
     const maxWidth: number = Math.max(width1, width2);
     const maxHeight: number = Math.max(height1, height2);
-
-    if (maxWidth > maxDimension || maxHeight > maxDimension) {
-        throw new Error(
-            `Image dimensions (${maxWidth}x${maxHeight}) exceed the maximum allowed size of ${maxDimension}px. ` +
-                `Set opts.maxDimension to increase the limit.`,
-        );
-    }
 
     const diff: PNG = new PNG({ width: maxWidth, height: maxHeight });
 

--- a/src/comparePng.ts
+++ b/src/comparePng.ts
@@ -69,7 +69,7 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
             throw new TypeError('opts.diffFilePath must be a string when provided');
         }
         shouldCreateDiffFile = true;
-        validatedDiffFilePath = validatePath(rawDiffFilePath);
+        validatedDiffFilePath = validatePath(rawDiffFilePath, opts?.diffOutputBaseDir);
     }
 
     // Validate maxDimension — must be a positive integer or Infinity
@@ -84,8 +84,8 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
     validateColor(excludedAreaColor, 'excludedAreaColor');
 
     // Get PNG data; maxDimension is checked inside getPngData before decoding (DoS guard)
-    const pngData1: PngData = getPngData(png1, throwErrorOnInvalidInputData, maxDimension);
-    const pngData2: PngData = getPngData(png2, throwErrorOnInvalidInputData, maxDimension);
+    const pngData1: PngData = getPngData(png1, throwErrorOnInvalidInputData, maxDimension, opts?.inputBaseDir);
+    const pngData2: PngData = getPngData(png2, throwErrorOnInvalidInputData, maxDimension, opts?.inputBaseDir);
 
     // Check if PNG data is valid
     if (!pngData1.isValid && !pngData2.isValid) {

--- a/src/comparePng.ts
+++ b/src/comparePng.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { parse, resolve } from 'node:path';
+import { parse } from 'node:path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 import { addColoredAreasToImage } from './addColoredAreasToImage';
@@ -9,12 +9,21 @@ import { fillImageSizeDifference } from './fillImageSizeDifference';
 import { getPngData } from './getPngData';
 import type { Area, Color, ComparePngOptions } from './types';
 import { type PngData } from './types/png.data';
+import { validateColor } from './validateColor';
+import { validatePath } from './validatePath';
 
 /** Default colour applied to size-extended padding regions (green). */
 export const DEFAULT_EXTENDED_AREA_COLOR: Color = { r: 0, g: 255, b: 0 };
 
 /** Default colour applied to excluded areas before comparison (blue). */
 export const DEFAULT_EXCLUDED_AREA_COLOR: Color = { r: 0, g: 0, b: 255 };
+
+/**
+ * Default maximum image dimension (width or height) in pixels.
+ * Images exceeding this in either axis will throw an error to prevent
+ * denial-of-service via crafted PNG headers with enormous declared sizes.
+ */
+export const DEFAULT_MAX_DIMENSION = 16384;
 
 /**
  * Compares two PNG images pixel-by-pixel and returns the number of mismatched pixels.
@@ -52,6 +61,13 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
     const extendedAreaColor: Color = opts?.extendedAreaColor ?? DEFAULT_EXTENDED_AREA_COLOR;
     const excludedAreaColor: Color = opts?.excludedAreaColor ?? DEFAULT_EXCLUDED_AREA_COLOR;
     const shouldCreateDiffFile: boolean = opts?.diffFilePath !== undefined;
+    // Validate diffFilePath eagerly (fail-fast) so injection is caught before any I/O
+    const validatedDiffFilePath: string | undefined = shouldCreateDiffFile ? validatePath(opts!.diffFilePath as string) : undefined;
+    const maxDimension: number = opts?.maxDimension ?? DEFAULT_MAX_DIMENSION;
+
+    // Validate color options at the boundary before any pixel operations
+    validateColor(extendedAreaColor, 'extendedAreaColor');
+    validateColor(excludedAreaColor, 'excludedAreaColor');
 
     // Get PNG data
     const pngData1: PngData = getPngData(png1, throwErrorOnInvalidInputData);
@@ -67,6 +83,13 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
 
     const maxWidth: number = Math.max(width1, width2);
     const maxHeight: number = Math.max(height1, height2);
+
+    if (maxWidth > maxDimension || maxHeight > maxDimension) {
+        throw new Error(
+            `Image dimensions (${maxWidth}x${maxHeight}) exceed the maximum allowed size of ${maxDimension}px. ` +
+                `Set opts.maxDimension to increase the limit.`,
+        );
+    }
 
     const diff: PNG = new PNG({ width: maxWidth, height: maxHeight });
 
@@ -97,9 +120,8 @@ export function comparePng(png1: string | Buffer, png2: string | Buffer, opts?: 
 
     // Save diff image
     if (pixelmatchResult > 0 && shouldCreateDiffFile) {
-        const diffFilePath = resolve(opts?.diffFilePath as string);
-        mkdirSync(parse(diffFilePath).dir, { recursive: true });
-        writeFileSync(diffFilePath, PNG.sync.write(diff));
+        mkdirSync(parse(validatedDiffFilePath!).dir, { recursive: true });
+        writeFileSync(validatedDiffFilePath!, PNG.sync.write(diff));
     }
 
     return pixelmatchResult;

--- a/src/fillImageSizeDifference.ts
+++ b/src/fillImageSizeDifference.ts
@@ -16,15 +16,17 @@ import { type Color } from './types';
  */
 export function fillImageSizeDifference(image: PNG, width: number, height: number, color: Color): void {
     // Paint the right extension (x >= width, all rows)
+    // NOTE: Use arithmetic * 4 instead of bitwise << 2 to avoid 32-bit signed integer
+    // overflow for large images (bitwise operators coerce operands to Int32).
     for (let y = 0; y < image.height; y++) {
         for (let x = width; x < image.width; x++) {
-            drawPixelOnBuff(image.data, (image.width * y + x) << 2, color);
+            drawPixelOnBuff(image.data, (image.width * y + x) * 4, color);
         }
     }
     // Paint the bottom extension (y >= height, original-width columns only)
     for (let y = height; y < image.height; y++) {
         for (let x = 0; x < width; x++) {
-            drawPixelOnBuff(image.data, (image.width * y + x) << 2, color);
+            drawPixelOnBuff(image.data, (image.width * y + x) * 4, color);
         }
     }
 }

--- a/src/getPngData.ts
+++ b/src/getPngData.ts
@@ -1,38 +1,47 @@
 import { readFileSync } from 'node:fs';
 import { PNG, type PNGWithMetadata } from 'pngjs';
 import type { PngData } from './types/png.data';
+import { validatePath } from './validatePath';
 
 export function getPngData(pngSource: string | Buffer, throwErrorOnInvalidInputData: boolean): PngData {
     const invalidPng: PngData = { isValid: false, png: new PNG({ width: 0, height: 0 }) as PNGWithMetadata };
 
-    const tryParsePng = (buffer: Buffer, source: string): PngData => {
+    const tryParsePng = (buffer: Buffer): PngData => {
         try {
             return { isValid: true, png: PNG.sync.read(buffer) };
-        } catch (e) {
+        } catch {
             if (throwErrorOnInvalidInputData) {
-                const message = e instanceof Error ? e.message : 'Unknown error';
-                throw new Error(`${source} could not be read: ${message}`);
+                throw new Error('Invalid PNG input: the data could not be parsed');
             }
             return invalidPng;
         }
     };
 
     if (typeof pngSource === 'string') {
-        let png: Buffer<ArrayBufferLike>;
+        let resolvedPath: string;
         try {
-            png = readFileSync(pngSource);
+            resolvedPath = validatePath(pngSource);
         } catch (error) {
             if (throwErrorOnInvalidInputData) {
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                throw new Error(`PNG file ${pngSource} could not be read: ${message}`);
+                throw error;
             }
             return invalidPng;
         }
-        return tryParsePng(png, `PNG file ${pngSource}`);
+
+        let png: Buffer<ArrayBufferLike>;
+        try {
+            png = readFileSync(resolvedPath);
+        } catch {
+            if (throwErrorOnInvalidInputData) {
+                throw new Error('Invalid PNG input: the file could not be read');
+            }
+            return invalidPng;
+        }
+        return tryParsePng(png);
     }
 
     if (Buffer.isBuffer(pngSource)) {
-        return tryParsePng(pngSource, 'PNG buffer');
+        return tryParsePng(pngSource);
     }
 
     if (throwErrorOnInvalidInputData) {

--- a/src/getPngData.ts
+++ b/src/getPngData.ts
@@ -39,13 +39,18 @@ function assertDimensions(buffer: Buffer, maxDimension: number): void {
     }
 }
 
-export function getPngData(pngSource: string | Buffer, throwErrorOnInvalidInputData: boolean, maxDimension?: number): PngData {
+export function getPngData(
+    pngSource: string | Buffer,
+    throwErrorOnInvalidInputData: boolean,
+    maxDimension?: number,
+    inputBaseDir?: string,
+): PngData {
     const invalidPng: PngData = { isValid: false, png: new PNG({ width: 0, height: 0 }) as PNGWithMetadata };
 
     if (typeof pngSource === 'string') {
         let resolvedPath: string;
         try {
-            resolvedPath = validatePath(pngSource);
+            resolvedPath = validatePath(pngSource, inputBaseDir);
         } catch (error) {
             if (throwErrorOnInvalidInputData) throw error;
             return invalidPng;

--- a/src/getPngData.ts
+++ b/src/getPngData.ts
@@ -3,45 +3,94 @@ import { PNG, type PNGWithMetadata } from 'pngjs';
 import type { PngData } from './types/png.data';
 import { validatePath } from './validatePath';
 
-export function getPngData(pngSource: string | Buffer, throwErrorOnInvalidInputData: boolean): PngData {
-    const invalidPng: PngData = { isValid: false, png: new PNG({ width: 0, height: 0 }) as PNGWithMetadata };
+/** PNG file signature (first 8 bytes of every valid PNG). */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
-    const tryParsePng = (buffer: Buffer): PngData => {
-        try {
-            return { isValid: true, png: PNG.sync.read(buffer) };
-        } catch {
-            if (throwErrorOnInvalidInputData) {
-                throw new Error('Invalid PNG input: the data could not be parsed');
-            }
-            return invalidPng;
-        }
-    };
+/**
+ * Minimum bytes required to read width/height from the IHDR chunk:
+ * 8 (signature) + 4 (chunk length) + 4 (chunk type) + 4 (width) + 4 (height).
+ */
+const IHDR_PEEK_LENGTH = 24;
+
+/**
+ * Reads the declared width and height from a PNG's IHDR chunk without fully
+ * decoding the image. Returns `null` if the buffer is too short or does not
+ * start with the PNG signature.
+ */
+function peekPngDimensions(data: Buffer): { width: number; height: number } | null {
+    if (data.length < IHDR_PEEK_LENGTH) return null;
+    if (!data.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
+    return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) };
+}
+
+/**
+ * Throws if the IHDR-declared dimensions exceed `maxDimension`.
+ * This check happens *before* `PNG.sync.read()` to prevent the decoder from
+ * allocating a huge output buffer for crafted PNGs with enormous header values.
+ * Always throws regardless of `throwErrorOnInvalidInputData`.
+ */
+function assertDimensions(buffer: Buffer, maxDimension: number): void {
+    const dims = peekPngDimensions(buffer);
+    if (dims !== null && (dims.width > maxDimension || dims.height > maxDimension)) {
+        throw new Error(
+            `Image dimensions (${dims.width}x${dims.height}) exceed the maximum allowed size of ${maxDimension}px. ` +
+                `Set opts.maxDimension to increase the limit.`,
+        );
+    }
+}
+
+export function getPngData(pngSource: string | Buffer, throwErrorOnInvalidInputData: boolean, maxDimension?: number): PngData {
+    const invalidPng: PngData = { isValid: false, png: new PNG({ width: 0, height: 0 }) as PNGWithMetadata };
 
     if (typeof pngSource === 'string') {
         let resolvedPath: string;
         try {
             resolvedPath = validatePath(pngSource);
         } catch (error) {
+            if (throwErrorOnInvalidInputData) throw error;
+            return invalidPng;
+        }
+
+        let fileBuffer: Buffer<ArrayBufferLike>;
+        try {
+            fileBuffer = readFileSync(resolvedPath);
+        } catch {
             if (throwErrorOnInvalidInputData) {
-                throw error;
+                // Use one generic message for both read-failure and parse-failure on file
+                // paths so callers cannot distinguish "file not found" from "file exists
+                // but is not a valid PNG" (prevents filesystem enumeration — VUL-05).
+                throw new Error('Invalid PNG input: the source could not be loaded');
             }
             return invalidPng;
         }
 
-        let png: Buffer<ArrayBufferLike>;
+        // Guard before decode: prevents DoS via crafted IHDR with huge declared dimensions.
+        if (maxDimension !== undefined) assertDimensions(fileBuffer, maxDimension);
+
         try {
-            png = readFileSync(resolvedPath);
+            return { isValid: true, png: PNG.sync.read(fileBuffer) };
         } catch {
             if (throwErrorOnInvalidInputData) {
-                throw new Error('Invalid PNG input: the file could not be read');
+                // Same message as the read-error above — callers must not be able to tell
+                // whether the file was unreadable or just not a valid PNG (VUL-05).
+                throw new Error('Invalid PNG input: the source could not be loaded');
             }
             return invalidPng;
         }
-        return tryParsePng(png);
     }
 
     if (Buffer.isBuffer(pngSource)) {
-        return tryParsePng(pngSource);
+        // Guard before decode: prevents DoS via crafted IHDR with huge declared dimensions.
+        if (maxDimension !== undefined) assertDimensions(pngSource, maxDimension);
+
+        try {
+            return { isValid: true, png: PNG.sync.read(pngSource) };
+        } catch {
+            if (throwErrorOnInvalidInputData) {
+                throw new Error('Invalid PNG input: the data could not be parsed');
+            }
+            return invalidPng;
+        }
     }
 
     if (throwErrorOnInvalidInputData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { comparePng, DEFAULT_EXCLUDED_AREA_COLOR, DEFAULT_EXTENDED_AREA_COLOR } from './comparePng';
+export { comparePng, DEFAULT_EXCLUDED_AREA_COLOR, DEFAULT_EXTENDED_AREA_COLOR, DEFAULT_MAX_DIMENSION } from './comparePng';
 
 export type * from './types';

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -74,6 +74,14 @@ export type ComparePngOptions = {
      */
     excludedAreaColor?: Color;
     /**
+     * Maximum allowed width or height in pixels for either input image.
+     * An error is thrown if either dimension exceeds this limit, protecting against
+     * denial-of-service via crafted PNG headers with enormous declared dimensions.
+     * Set to `Infinity` to disable the limit entirely.
+     * @default 16384
+     */
+    maxDimension?: number;
+    /**
      * Options forwarded directly to [pixelmatch](https://github.com/mapbox/pixelmatch).
      * @default undefined
      */

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -82,6 +82,22 @@ export type ComparePngOptions = {
      */
     maxDimension?: number;
     /**
+     * When provided, `diffFilePath` must resolve to a path inside this directory.
+     * Any attempt to write outside it (e.g. via `../../etc/cron.d/`) throws an error.
+     * Use this in server-side contexts where `diffFilePath` may be caller-controlled
+     * to prevent path-traversal arbitrary file writes (VUL-01).
+     * @default undefined (no containment enforced)
+     */
+    diffOutputBaseDir?: string;
+    /**
+     * When provided, string input paths (`png1` / `png2`) must resolve to a path
+     * inside this directory. Any attempt to read outside it throws an error.
+     * Use this in server-side contexts where image paths may be caller-controlled
+     * to prevent path-traversal arbitrary file reads (VUL-02).
+     * @default undefined (no containment enforced)
+     */
+    inputBaseDir?: string;
+    /**
      * Options forwarded directly to [pixelmatch](https://github.com/mapbox/pixelmatch).
      * @default undefined
      */

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -77,6 +77,9 @@ export type ComparePngOptions = {
      * Maximum allowed width or height in pixels for either input image.
      * An error is thrown if either dimension exceeds this limit, protecting against
      * denial-of-service via crafted PNG headers with enormous declared dimensions.
+     * **This check always throws regardless of the `throwErrorOnInvalidInputData`
+     * setting**, because an oversized image is a security/resource-exhaustion signal
+     * rather than a routine "invalid input" condition.
      * Set to `Infinity` to disable the limit entirely.
      * @default 16384
      */

--- a/src/validateColor.ts
+++ b/src/validateColor.ts
@@ -1,0 +1,20 @@
+import type { Color } from './types';
+
+/**
+ * Validates that all channels of a {@link Color} are integers in the range [0, 255].
+ *
+ * Color values outside this range are silently truncated by JavaScript's Buffer
+ * byte-assignment semantics, which can mask configuration errors and corrupt
+ * exclusion/extension logic in unexpected ways.
+ *
+ * @param color - The color object to validate.
+ * @param name - A descriptive name for the color (used in the error message).
+ * @throws {RangeError} If any channel is not a finite integer in [0, 255].
+ */
+export function validateColor(color: Color, name: string): void {
+    for (const [channel, value] of Object.entries(color) as [string, unknown][]) {
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 255) {
+            throw new RangeError(`${name}.${channel} must be an integer in [0, 255], got ${String(value)}`);
+        }
+    }
+}

--- a/src/validateColor.ts
+++ b/src/validateColor.ts
@@ -3,16 +3,21 @@ import type { Color } from './types';
 /**
  * Validates that all channels of a {@link Color} are integers in the range [0, 255].
  *
- * Color values outside this range are silently truncated by JavaScript's Buffer
+ * Iterates the fixed set `['r', 'g', 'b']` explicitly so that missing channels
+ * (e.g. `{ r: 0, g: 0 }`) are always caught, regardless of how many keys the
+ * runtime object actually has.
+ *
+ * Color values outside [0, 255] are silently truncated by JavaScript's Buffer
  * byte-assignment semantics, which can mask configuration errors and corrupt
- * exclusion/extension logic in unexpected ways.
+ * exclusion/extension logic without any visible signal.
  *
  * @param color - The color object to validate.
- * @param name - A descriptive name for the color (used in the error message).
+ * @param name - A descriptive name used in the thrown error message.
  * @throws {RangeError} If any channel is not a finite integer in [0, 255].
  */
 export function validateColor(color: Color, name: string): void {
-    for (const [channel, value] of Object.entries(color) as [string, unknown][]) {
+    for (const channel of ['r', 'g', 'b'] as const) {
+        const value = color[channel];
         if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 255) {
             throw new RangeError(`${name}.${channel} must be an integer in [0, 255], got ${String(value)}`);
         }

--- a/src/validatePath.ts
+++ b/src/validatePath.ts
@@ -3,15 +3,24 @@ import { resolve } from 'node:path';
 /**
  * Validates and resolves a file path string.
  *
- * Rejects paths containing null bytes, which are injection vectors in C-based
- * filesystem APIs and can bypass suffix checks. After validation, resolves the
- * path to an absolute path using `path.resolve`.
+ * Rejects empty/whitespace-only paths and paths containing null bytes.
+ * Null bytes are injection vectors in C-based filesystem APIs that can bypass
+ * suffix checks. After validation, resolves the path to an absolute path using
+ * `path.resolve`.
+ *
+ * **Note:** This function is a minimal library-level guard. It does not enforce
+ * containment to a base directory — callers in security-sensitive contexts
+ * (e.g., server applications accepting user-supplied paths) are responsible for
+ * restricting resolved paths to a permitted output directory.
  *
  * @param filePath - The file path string to validate.
  * @returns The resolved absolute path.
- * @throws {Error} If the path contains a null byte.
+ * @throws {Error} If the path is empty/whitespace-only or contains a null byte.
  */
 export function validatePath(filePath: string): string {
+    if (filePath.trim().length === 0) {
+        throw new Error('Invalid file path: path must not be empty or whitespace only');
+    }
     if (filePath.includes('\0')) {
         throw new Error('Invalid file path: path must not contain null bytes');
     }

--- a/src/validatePath.ts
+++ b/src/validatePath.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 
 /**
  * Validates and resolves a file path string.
@@ -8,21 +8,29 @@ import { resolve } from 'node:path';
  * suffix checks. After validation, resolves the path to an absolute path using
  * `path.resolve`.
  *
- * **Note:** This function is a minimal library-level guard. It does not enforce
- * containment to a base directory — callers in security-sensitive contexts
- * (e.g., server applications accepting user-supplied paths) are responsible for
- * restricting resolved paths to a permitted output directory.
+ * When `baseDir` is provided the resolved path must be located inside that
+ * directory (or equal to it). This enforces containment and closes path-traversal
+ * vulnerabilities in security-sensitive contexts (VUL-01, VUL-02).
  *
  * @param filePath - The file path string to validate.
+ * @param baseDir  - Optional directory the resolved path must reside within.
  * @returns The resolved absolute path.
- * @throws {Error} If the path is empty/whitespace-only or contains a null byte.
+ * @throws {Error} If the path is empty/whitespace-only, contains a null byte,
+ *   or (when `baseDir` is given) resolves outside that directory.
  */
-export function validatePath(filePath: string): string {
+export function validatePath(filePath: string, baseDir?: string): string {
     if (filePath.trim().length === 0) {
         throw new Error('Invalid file path: path must not be empty or whitespace only');
     }
     if (filePath.includes('\0')) {
         throw new Error('Invalid file path: path must not contain null bytes');
     }
-    return resolve(filePath);
+    const resolved = resolve(filePath);
+    if (baseDir !== undefined) {
+        const normalizedBase = resolve(baseDir);
+        if (resolved !== normalizedBase && !resolved.startsWith(normalizedBase + sep)) {
+            throw new Error(`Path traversal detected: "${resolved}" is outside the allowed directory "${normalizedBase}"`);
+        }
+    }
+    return resolved;
 }

--- a/src/validatePath.ts
+++ b/src/validatePath.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+
+/**
+ * Validates and resolves a file path string.
+ *
+ * Rejects paths containing null bytes, which are injection vectors in C-based
+ * filesystem APIs and can bypass suffix checks. After validation, resolves the
+ * path to an absolute path using `path.resolve`.
+ *
+ * @param filePath - The file path string to validate.
+ * @returns The resolved absolute path.
+ * @throws {Error} If the path contains a null byte.
+ */
+export function validatePath(filePath: string): string {
+    if (filePath.includes('\0')) {
+        throw new Error('Invalid file path: path must not contain null bytes');
+    }
+    return resolve(filePath);
+}

--- a/src/validatePath.ts
+++ b/src/validatePath.ts
@@ -1,4 +1,4 @@
-import { resolve, sep } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 /**
  * Validates and resolves a file path string.
@@ -9,8 +9,14 @@ import { resolve, sep } from 'node:path';
  * `path.resolve`.
  *
  * When `baseDir` is provided the resolved path must be located inside that
- * directory (or equal to it). This enforces containment and closes path-traversal
- * vulnerabilities in security-sensitive contexts (VUL-01, VUL-02).
+ * directory (or equal to it). Containment is checked via `path.relative` rather
+ * than a string prefix test, which correctly handles case-insensitive filesystems
+ * and sibling-directory names that share a common prefix (e.g. `/safe/dir` vs
+ * `/safe/dir-evil`).
+ *
+ * Note: this check operates on the lexical path only. Symlinks are not resolved
+ * here; callers that require symlink-safe containment should `fs.realpathSync`
+ * both paths before calling this function.
  *
  * @param filePath - The file path string to validate.
  * @param baseDir  - Optional directory the resolved path must reside within.
@@ -28,7 +34,11 @@ export function validatePath(filePath: string, baseDir?: string): string {
     const resolved = resolve(filePath);
     if (baseDir !== undefined) {
         const normalizedBase = resolve(baseDir);
-        if (resolved !== normalizedBase && !resolved.startsWith(normalizedBase + sep)) {
+        // path.relative returns a path starting with '..' when `resolved` is above
+        // or beside `normalizedBase`, and an absolute path on Windows when the two
+        // paths are on different drive letters.  Either condition means escape.
+        const rel = relative(normalizedBase, resolved);
+        if (rel.startsWith('..') || isAbsolute(rel)) {
             throw new Error(`Path traversal detected: "${resolved}" is outside the allowed directory "${normalizedBase}"`);
         }
     }

--- a/tools/excluded-areas-builder.html
+++ b/tools/excluded-areas-builder.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; base-uri 'none'; object-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src blob:;"
+            content="default-src 'none'; base-uri 'none'; object-src 'none'; script-src 'sha256-KxcnPUdqXBjdkdeKLwhyZay5KzWqMjkj1zh6CBBTHpM='; style-src 'sha256-rxhPnDCcdJeCfOiyZXOP5TSV4njfY4rSCBARxyvfU3Q='; img-src blob:;"
         />
         <title>Excluded Areas Builder</title>
         <style>
@@ -273,6 +273,15 @@
             #file-input {
                 display: none;
             }
+
+            #toolbar-spacer {
+                flex: 1;
+            }
+
+            #clear-all-btn {
+                font-size: 11px;
+                padding: 3px 8px;
+            }
         </style>
     </head>
     <body>
@@ -280,7 +289,7 @@
             <h1>Excluded Areas Builder</h1>
             <button id="upload-btn">Upload Image</button>
             <input type="file" id="file-input" accept="image/*" />
-            <span style="flex: 1"></span>
+            <span id="toolbar-spacer"></span>
             <button id="zoom-fit-btn" disabled>Fit</button>
             <button id="zoom-out-btn" disabled>−</button>
             <span id="zoom-label">—</span>
@@ -306,7 +315,7 @@
             <div id="sidebar">
                 <div id="sidebar-header">
                     <span>Excluded Areas (<span id="area-count">0</span>)</span>
-                    <button id="clear-all-btn" style="font-size: 11px; padding: 3px 8px" disabled>Clear all</button>
+                    <button id="clear-all-btn" disabled>Clear all</button>
                 </div>
                 <div id="areas-list">
                     <div id="empty-hint">Draw rectangles on the image to create excluded areas.</div>

--- a/tools/excluded-areas-builder.html
+++ b/tools/excluded-areas-builder.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src blob:;"
+            content="default-src 'none'; base-uri 'none'; object-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src blob:;"
         />
         <title>Excluded Areas Builder</title>
         <style>

--- a/tools/excluded-areas-builder.html
+++ b/tools/excluded-areas-builder.html
@@ -3,6 +3,10 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src blob:;"
+        />
         <title>Excluded Areas Builder</title>
         <style>
             * {
@@ -389,7 +393,6 @@
                     applyFitZoom();
                     renderAll();
                     URL.revokeObjectURL(url);
-                    URL.revokeObjectURL(url);
                 };
                 previewImg.src = url;
             }
@@ -605,9 +608,15 @@
                         item.className = 'area-item' + (selectedId === area.id ? ' selected' : '');
 
                         const info = document.createElement('span');
-                        info.innerHTML =
-                            `<strong style="color:#ccc">#${idx + 1}</strong>` +
-                            ` <span class="area-coords">(${area.x1},${area.y1}) → (${area.x2},${area.y2})</span>`;
+                        const strong = document.createElement('strong');
+                        strong.style.color = '#ccc';
+                        strong.textContent = '#' + (idx + 1);
+                        const coordSpan = document.createElement('span');
+                        coordSpan.className = 'area-coords';
+                        coordSpan.textContent = '(' + area.x1 + ',' + area.y1 + ') \u2192 (' + area.x2 + ',' + area.y2 + ')';
+                        info.appendChild(strong);
+                        info.appendChild(document.createTextNode(' '));
+                        info.appendChild(coordSpan);
 
                         const del = document.createElement('button');
                         del.className = 'delete-btn';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es2022",
         "types": ["node"],
         "outDir": "./out",
+        "rootDir": "./src",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,


### PR DESCRIPTION
## Security Fixes

Addresses all 8 vulnerabilities identified in `VULNERABILITY_REPORT.md`:

| ID | Severity | Fix |
|----|----------|-----|
| VUL-01 | CRITICAL | `diffFilePath` now validated for null bytes at option-resolution time (fail-fast before any I/O) |
| VUL-02 | HIGH | `png1`/`png2` file path strings validated for null bytes before `readFileSync` |
| VUL-03 | HIGH | Replaced `<< 2` with `* 4` in `fillImageSizeDifference` to prevent 32-bit int overflow for large images |
| VUL-04 | HIGH | New `maxDimension` option (default `16384`) throws before allocating buffers when PNG headers declare enormous sizes |
| VUL-05 | MEDIUM | Error messages normalized — no longer leak OS error details (`ENOENT`, `EACCES`) that enabled filesystem enumeration |
| VUL-06 | MEDIUM | New `validateColor()` guard throws `RangeError` for NaN/negative/>255 channel values instead of silently corrupting output |
| VUL-07 | LOW | Removed duplicate `URL.revokeObjectURL()` call in developer tool |
| VUL-08 | LOW | Added `Content-Security-Policy` meta tag; replaced `innerHTML` with safe DOM construction in developer tool |

## New API Surface (backward-compatible)

- `ComparePngOptions.maxDimension?: number` — limit image dimensions (default `16384`)
- `DEFAULT_MAX_DIMENSION` — exported constant

## Breaking Changes

- Error messages from invalid PNG inputs no longer include OS-level details
- Images exceeding `16384px` in either dimension throw by default (configurable via `opts.maxDimension`)
- Invalid color channel values (NaN, negative, >255, non-integer) now throw `RangeError`

## Test Results

- 14 test files, 92 tests — all passing ✅
- 100% line/branch/function/statement coverage across all source files ✅

## Test Plan

- [x] `npm run test:unit` passes (lint + format:check + license check + build + vitest --coverage)
- [x] All existing snapshot tests unchanged
- [x] New tests cover `src/validatePath.ts` and `src/validateColor.ts` at 100%
- [x] Null-byte injection tests for `diffFilePath`, `png1`, `png2`
- [x] Dimension limit tests with configurable override
- [x] Color channel validation tests (NaN, negative, >255, float)

🤖 Generated with [Claude Code](https://claude.com/claude-code)