### PR TITLE
fix(security): close TOCTOU symlink window on diff write (SECU-03)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -804,7 +804,8 @@ When unblocked, the agent should:
 ## [SECU-03] Make diff write symlink-atomic
 
 **Priority:** P1  
-**Status:** Open  
+**Status:** Done  
+**Shipped:** 2026-05-16 (`6.1.1`) via `O_NOFOLLOW` on both `fsDiffWriter` and `fsAsyncDiffWriter`; behaviour preserved for regular-file overwrite; symlink at target now refused with `PathValidationError`. Residual parent-directory race tracked as `SECU-09`.  
 **Requires:** nothing  
 **Problem:** `src/ports/fsDiffWriter.ts` and `src/ports/fsAsyncDiffWriter.ts` write the diff PNG via `writeFileSync(path, data)` / `writeFile(path, data)`, both of which follow symlinks by default. `validatePath` correctly rejects an _existing_ symlink at the target path under output mode, but between that validation and the actual write a hostile or buggy process can plant a symlink at `diffFilePath`, causing the diff bytes to be written to an arbitrary destination outside `diffOutputBaseDir`.
 
@@ -911,6 +912,33 @@ if (filePath.length > 4096) {
 ```
 
 4096 is Linux `PATH_MAX`; macOS `pathconf(_PC_PATH_MAX)` is 1024 but APFS tolerates longer. A 4096-byte cap is permissive enough not to false-trigger on real paths and strict enough to refuse pathological inputs.
+
+## [SECU-09] `mkdirSync(recursive)` can cross a symlink planted in a parent directory component
+
+**Priority:** P2  
+**Status:** Open  
+**Filed:** 2026-05-16 as a follow-on from SECU-03 (target-path race closed; parent-component race deferred).  
+**Problem:** Both `fsDiffWriter` and `fsAsyncDiffWriter` call `mkdirSync(parse(path).dir, { recursive: true })` (or its async equivalent) before opening the target file. `mkdir` does **not** refuse symlinks in path components; if an attacker plants a symlink at any ancestor of `diffFilePath` between `validatePath` (which `realpath`s the longest existing parent) and the `mkdir` call, the diff write proceeds through that symlink. SECU-03 closed the race at the final path component via `O_NOFOLLOW`; this item is the analogous closure for intermediate components.
+
+**Technical rationale:** `validatePath` performs a `realpath` of the longest existing parent at validate-time. Between that point and `mkdirSync`, an attacker can `mkdir`/`ln -s` a new component that bypasses containment. The threat is narrower than SECU-03 because the attacker must control a directory inside `diffOutputBaseDir`, but the same `diffOutputBaseDir` security boundary is the one we claim to enforce.
+
+**Suggested approach:**
+
+- Walk the path segments manually (`path.relative(baseDir, target).split(path.sep)`), and for each non-existent segment, `mkdir` it without `recursive: true` and re-`lstat` it after creation to confirm it is a real directory (not a symlink). On any `lstat` mismatch, throw `PathValidationError`.
+- Alternative: skip the `mkdir` step in the writer entirely and document that callers must pre-create `diffFilePath`'s parent directory. Smaller code; larger behaviour shift.
+
+**Files to modify:**
+
+- `src/ports/fsDiffWriter.ts`, `src/ports/fsAsyncDiffWriter.ts` — replace `mkdirSync(parent, { recursive: true })` with a per-segment loop that lstats each created directory.
+- `src/types/compare.options.ts` — once closed, retract the "parent-directory race remains" caveat in the `diffFilePath` and `diffOutputBaseDir` TSDoc.
+- New test files mirroring `fsDiffWriter.symlink.test.ts` / `fsAsyncDiffWriter.symlink.test.ts` — assert that a symlink planted between `validatePath` and the per-segment `mkdir` is refused.
+
+**Acceptance criteria:**
+
+- Diff write refuses to traverse a symlink in any ancestor of `diffFilePath`
+- TSDoc on `diffFilePath` and `diffOutputBaseDir` no longer flags a residual parent-dir race
+- Coverage stays at 100 %
+- Symlink-in-parent test passes on Linux and macOS; Windows guarded as elsewhere
 
 ## [PERF-04] Skip eager clone in `normalizeImages` when no mutation follows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.1] - 2026-05-16
+
+### Security
+
+- **SECU-03** — Closed the TOCTOU symlink-redirect window on diff writes. The
+  diff PNG is now written through an `O_NOFOLLOW` open, so a symlink planted at
+  `diffFilePath` between `validatePath` and the write is refused with a
+  `PathValidationError` instead of being followed. Regular-file overwrite
+  semantics are preserved; only the symlink-redirect attack is closed.
+- TSDoc on `diffFilePath` documents the new symlink-refusal contract and
+  `@throws PathValidationError`. TSDoc on `diffOutputBaseDir` clarifies that the
+  target-path race is now closed at write-time, while the residual
+  parent-directory race is tracked as `SECU-09`.
+
 ## [6.0.0] - 2026-04-25
 
 ### Added

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.1.1"
     },
-    "sourceHash": "0d37d17860a88e76df714d54188f937cefd9131353ffb53f716eadcfbd922e44",
+    "sourceHash": "4673016f4f19362202d139f68a524fc9c15c6c60991faa85bb8d16fa4d2b5df3",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -12,9 +12,9 @@ Schema: `codemap.v2`
     "schema": "codemap.v2",
     "repo": {
         "name": "png-visual-compare",
-        "version": "6.1.0"
+        "version": "6.1.1"
     },
-    "sourceHash": "0a8b9bd3f9704e3c9d3b39b3d5c5301a48496d996d5af0c747ce2544afe69deb",
+    "sourceHash": "0d37d17860a88e76df714d54188f937cefd9131353ffb53f716eadcfbd922e44",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -1252,17 +1252,28 @@ Schema: `codemap.v2`
             "path": "src/ports/fsAsyncDiffWriter.ts",
             "symbols": [
                 {
+                    "name": "SYMLINK_REFUSING_WRITE_FLAGS",
+                    "kind": "const",
+                    "line": 7,
+                    "exported": false,
+                    "signature": "const SYMLINK_REFUSING_WRITE_FLAGS",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
                     "name": "fsAsyncDiffWriter",
                     "kind": "const",
-                    "line": 5,
+                    "line": 9,
                     "exported": true,
-                    "signature": "export const fsAsyncDiffWriter: AsyncDiffWriterPort = { async write(path, data) { await mkdir(parse(path).dir, { recursive: true }); await writeFile(path, data); }, }",
+                    "signature": "export const fsAsyncDiffWriter: AsyncDiffWriterPort = { async write(path, data) { await mkdir(parse(path).dir, { recursive: true }); try { const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS)…",
                     "members": null,
                     "jsdoc": null
                 }
             ],
             "imports": [
+                "../errors",
                 "./asyncTypes",
+                "node:fs",
                 "node:fs/promises",
                 "node:path"
             ],
@@ -1294,16 +1305,26 @@ Schema: `codemap.v2`
             "path": "src/ports/fsDiffWriter.ts",
             "symbols": [
                 {
+                    "name": "SYMLINK_REFUSING_WRITE_FLAGS",
+                    "kind": "const",
+                    "line": 6,
+                    "exported": false,
+                    "signature": "const SYMLINK_REFUSING_WRITE_FLAGS",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
                     "name": "fsDiffWriter",
                     "kind": "const",
-                    "line": 5,
+                    "line": 8,
                     "exported": true,
-                    "signature": "export const fsDiffWriter: DiffWriterPort = { write(path, data) { mkdirSync(parse(path).dir, { recursive: true }); writeFileSync(path, data); }, }",
+                    "signature": "export const fsDiffWriter: DiffWriterPort = { write(path, data) { mkdirSync(parse(path).dir, { recursive: true }); let fd: number; try { fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS); } catch (err…",
                     "members": null,
                     "jsdoc": null
                 }
             ],
             "imports": [
+                "../errors",
                 "./types",
                 "node:fs",
                 "node:path"

--- a/__tests__/comparePng.symlink-toctou.test.ts
+++ b/__tests__/comparePng.symlink-toctou.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { PNG } from 'pngjs';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PathValidationError } from '../src';
+import { comparePngWithPorts } from '../src/comparePng';
+import { fsDiffWriter } from '../src/ports/fsDiffWriter';
+import { fsImageSource } from '../src/ports/fsImageSource';
+import type { ComparisonPorts } from '../src/ports/types';
+
+function pngBuffer(rgba: [number, number, number, number]): Buffer {
+    const png = new PNG({ width: 2, height: 2, fill: true });
+    for (let i = 0; i < png.data.length; i += 4) {
+        png.data[i] = rgba[0];
+        png.data[i + 1] = rgba[1];
+        png.data[i + 2] = rgba[2];
+        png.data[i + 3] = rgba[3];
+    }
+    return PNG.sync.write(png);
+}
+
+describe('comparePng TOCTOU defence on diff write (SECU-03)', () => {
+    const rootDir = path.resolve('./test-results/compare-png-symlink-toctou');
+    const diffFilePath = path.join(rootDir, 'diff.png');
+    const sentinel = path.join(rootDir, 'sentinel.txt');
+    const png1 = pngBuffer([255, 0, 0, 255]);
+    const png2 = pngBuffer([0, 255, 0, 255]);
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(rootDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('refuses to write through a symlink planted between validation and write; sentinel is preserved', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        writeFileSync(sentinel, 'sentinel-bytes');
+
+        const planSymlinkBeforeWrite: ComparisonPorts = {
+            imageSource: fsImageSource,
+            diffWriter: {
+                write(targetPath, data) {
+                    // Race emulation: validatePath has already cleared this path
+                    // (no symlink existed). A hostile process now plants one
+                    // before the writer opens the file. The writer must refuse.
+                    symlinkSync(sentinel, targetPath);
+                    fsDiffWriter.write(targetPath, data);
+                },
+            },
+        };
+
+        expect(() => comparePngWithPorts(png1, png2, { diffFilePath }, planSymlinkBeforeWrite)).toThrow(PathValidationError);
+
+        expect(readFileSync(sentinel).toString()).toBe('sentinel-bytes');
+        expect(lstatSync(diffFilePath).isSymbolicLink()).toBe(true);
+        expect(existsSync(path.join(rootDir, 'should-not-exist.png'))).toBe(false);
+    });
+});

--- a/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PathValidationError } from '../../src';
+import { fsAsyncDiffWriter } from '../../src/ports/fsAsyncDiffWriter';
+import type { ValidatedPath } from '../../src/types/validated-path';
+
+function asValidatedPath(p: string): ValidatedPath {
+    return p as unknown as ValidatedPath;
+}
+
+describe('fsAsyncDiffWriter symlink refusal (SECU-03)', () => {
+    const rootDir = path.resolve('./test-results/fs-async-diff-writer-symlink');
+    const target = path.join(rootDir, 'diff.png');
+    const sentinel = path.join(rootDir, 'sentinel.txt');
+    const sentinelDir = path.join(rootDir, 'sentinel-dir');
+    const payload = Buffer.from('PNG-PAYLOAD-BYTES');
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(rootDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('writes a new file when the target does not exist', async () => {
+        await fsAsyncDiffWriter.write(asValidatedPath(target), payload);
+        expect(readFileSync(target)).toEqual(payload);
+    });
+
+    test('overwrites an existing regular file (overwrite contract preserved)', async () => {
+        writeFileSync(target, 'stale-bytes');
+        await fsAsyncDiffWriter.write(asValidatedPath(target), payload);
+        expect(readFileSync(target)).toEqual(payload);
+    });
+
+    test('refuses to write when the target is a symlink to a non-existent file', async () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        const dangling = path.join(rootDir, 'dangling.txt');
+        symlinkSync(dangling, target);
+
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(target), payload)).rejects.toBeInstanceOf(PathValidationError);
+        expect(existsSync(dangling)).toBe(false);
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('refuses to write when the target is a symlink to an existing file; sentinel is preserved byte-for-byte', async () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        writeFileSync(sentinel, 'sentinel-bytes');
+        symlinkSync(sentinel, target);
+
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(target), payload)).rejects.toBeInstanceOf(PathValidationError);
+        expect(readFileSync(sentinel).toString()).toBe('sentinel-bytes');
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('refuses to write when the target is a symlink to a directory', async () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        mkdirSync(sentinelDir);
+        symlinkSync(sentinelDir, target);
+
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(target), payload)).rejects.toBeInstanceOf(PathValidationError);
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('propagates non-symlink open errors raw (e.g. EISDIR when target is a real directory)', async () => {
+        const dirTarget = path.join(rootDir, 'is-a-directory');
+        mkdirSync(dirTarget);
+
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(dirTarget), payload)).rejects.toMatchObject({ code: 'EISDIR' });
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(dirTarget), payload)).rejects.not.toBeInstanceOf(PathValidationError);
+    });
+
+    test('wraps the symlink refusal in PathValidationError with a recognisable message', async () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        const forbidden = path.join(rootDir, 'forbidden.txt');
+        symlinkSync(forbidden, target);
+
+        await expect(fsAsyncDiffWriter.write(asValidatedPath(target), payload)).rejects.toThrow(/symlink/);
+        expect(existsSync(forbidden)).toBe(false);
+    });
+});

--- a/__tests__/ports/fsDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsDiffWriter.symlink.test.ts
@@ -1,0 +1,100 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PathValidationError } from '../../src';
+import { fsDiffWriter } from '../../src/ports/fsDiffWriter';
+import type { ValidatedPath } from '../../src/types/validated-path';
+
+function asValidatedPath(p: string): ValidatedPath {
+    return p as unknown as ValidatedPath;
+}
+
+describe('fsDiffWriter symlink refusal (SECU-03)', () => {
+    const rootDir = path.resolve('./test-results/fs-diff-writer-symlink');
+    const target = path.join(rootDir, 'diff.png');
+    const sentinel = path.join(rootDir, 'sentinel.txt');
+    const sentinelDir = path.join(rootDir, 'sentinel-dir');
+    const payload = Buffer.from('PNG-PAYLOAD-BYTES');
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(rootDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('writes a new file when the target does not exist', () => {
+        fsDiffWriter.write(asValidatedPath(target), payload);
+        expect(readFileSync(target)).toEqual(payload);
+    });
+
+    test('overwrites an existing regular file (overwrite contract preserved)', () => {
+        writeFileSync(target, 'stale-bytes');
+        fsDiffWriter.write(asValidatedPath(target), payload);
+        expect(readFileSync(target)).toEqual(payload);
+    });
+
+    test('refuses to write when the target is a symlink to a non-existent file', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        const dangling = path.join(rootDir, 'dangling.txt');
+        symlinkSync(dangling, target);
+
+        expect(() => fsDiffWriter.write(asValidatedPath(target), payload)).toThrow(PathValidationError);
+        expect(existsSync(dangling)).toBe(false);
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('refuses to write when the target is a symlink to an existing file; sentinel is preserved byte-for-byte', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        writeFileSync(sentinel, 'sentinel-bytes');
+        symlinkSync(sentinel, target);
+
+        expect(() => fsDiffWriter.write(asValidatedPath(target), payload)).toThrow(PathValidationError);
+        expect(readFileSync(sentinel).toString()).toBe('sentinel-bytes');
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('refuses to write when the target is a symlink to a directory', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        mkdirSync(sentinelDir);
+        symlinkSync(sentinelDir, target);
+
+        expect(() => fsDiffWriter.write(asValidatedPath(target), payload)).toThrow(PathValidationError);
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    test('propagates non-symlink open errors raw (e.g. EISDIR when target is a real directory)', () => {
+        const dirTarget = path.join(rootDir, 'is-a-directory');
+        mkdirSync(dirTarget);
+
+        try {
+            fsDiffWriter.write(asValidatedPath(dirTarget), payload);
+            throw new Error('Expected fsDiffWriter.write to throw');
+        } catch (error) {
+            expect(error).not.toBeInstanceOf(PathValidationError);
+            expect((error as NodeJS.ErrnoException).code).toBe('EISDIR');
+        }
+    });
+
+    test('wraps the symlink refusal in PathValidationError with a recognisable message', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        const forbidden = path.join(rootDir, 'forbidden.txt');
+        symlinkSync(forbidden, target);
+
+        try {
+            fsDiffWriter.write(asValidatedPath(target), payload);
+            throw new Error('Expected fsDiffWriter.write to throw PathValidationError');
+        } catch (error) {
+            expect(error).toBeInstanceOf(PathValidationError);
+            expect((error as Error).message).toContain('symlink');
+        }
+
+        expect(existsSync(forbidden)).toBe(false);
+    });
+});

--- a/__tests__/ports/fsDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsDiffWriter.symlink.test.ts
@@ -36,6 +36,19 @@ describe('fsDiffWriter symlink refusal (SECU-03)', () => {
         expect(readFileSync(target)).toEqual(payload);
     });
 
+    test('writes the full buffer byte-for-byte for multi-megabyte payloads (no partial-write truncation)', () => {
+        const largePayload = Buffer.alloc(4 * 1024 * 1024); // 4 MiB
+        for (let i = 0; i < largePayload.length; i++) {
+            largePayload[i] = i & 0xff;
+        }
+
+        fsDiffWriter.write(asValidatedPath(target), largePayload);
+
+        const written = readFileSync(target);
+        expect(written.length).toBe(largePayload.length);
+        expect(written.equals(largePayload)).toBe(true);
+    });
+
     test('refuses to write when the target is a symlink to a non-existent file', () => {
         if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
             },
             "devDependencies": {
                 "@playwright/test": "~1.60.0",
-                "@types/node": "~25.7.0",
+                "@types/node": "~25.8.0",
                 "@types/pngjs": "~6.0.5",
                 "@vitest/coverage-v8": "~4.1.6",
-                "eslint": "~10.3.0",
+                "eslint": "~10.4.0",
                 "prettier": "~3.8.3",
                 "rimraf": "~6.1.3",
                 "typescript": "~6.0.3",
@@ -200,9 +200,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -363,9 +363,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.129.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+            "version": "0.130.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+            "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -389,9 +389,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-            "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+            "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
             "cpu": [
                 "arm64"
             ],
@@ -406,9 +406,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-            "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+            "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
             "cpu": [
                 "arm64"
             ],
@@ -423,9 +423,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-            "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+            "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
             "cpu": [
                 "x64"
             ],
@@ -440,9 +440,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-            "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+            "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
             "cpu": [
                 "x64"
             ],
@@ -457,9 +457,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-            "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+            "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
             "cpu": [
                 "arm"
             ],
@@ -474,9 +474,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-            "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+            "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
             "cpu": [
                 "arm64"
             ],
@@ -494,9 +494,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-            "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+            "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
             "cpu": [
                 "arm64"
             ],
@@ -514,9 +514,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-            "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+            "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
             "cpu": [
                 "ppc64"
             ],
@@ -534,9 +534,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-            "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+            "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
             "cpu": [
                 "s390x"
             ],
@@ -554,9 +554,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-            "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+            "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
             "cpu": [
                 "x64"
             ],
@@ -574,9 +574,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-            "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+            "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-            "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+            "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
             "cpu": [
                 "arm64"
             ],
@@ -611,9 +611,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-            "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+            "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -630,9 +630,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-            "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+            "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
             "cpu": [
                 "arm64"
             ],
@@ -647,9 +647,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-            "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+            "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
             "cpu": [
                 "x64"
             ],
@@ -664,9 +664,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-            "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -728,13 +728,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.7.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-            "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+            "version": "25.8.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.21.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/pngjs": {
@@ -1294,16 +1294,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-            "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",
@@ -2069,13 +2069,13 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
+                "@babel/parser": "^7.29.3",
                 "@babel/types": "^7.29.0",
                 "source-map-js": "^1.2.1"
             }
@@ -2426,14 +2426,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-            "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+            "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.129.0",
-                "@rolldown/pluginutils": "1.0.0"
+                "@oxc-project/types": "=0.130.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -2442,21 +2442,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0",
-                "@rolldown/binding-darwin-arm64": "1.0.0",
-                "@rolldown/binding-darwin-x64": "1.0.0",
-                "@rolldown/binding-freebsd-x64": "1.0.0",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-musl": "1.0.0",
-                "@rolldown/binding-openharmony-arm64": "1.0.0",
-                "@rolldown/binding-wasm32-wasi": "1.0.0",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0"
+                "@rolldown/binding-android-arm64": "1.0.1",
+                "@rolldown/binding-darwin-arm64": "1.0.1",
+                "@rolldown/binding-darwin-x64": "1.0.1",
+                "@rolldown/binding-freebsd-x64": "1.0.1",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+                "@rolldown/binding-linux-arm64-musl": "1.0.1",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+                "@rolldown/binding-linux-x64-gnu": "1.0.1",
+                "@rolldown/binding-linux-x64-musl": "1.0.1",
+                "@rolldown/binding-openharmony-arm64": "1.0.1",
+                "@rolldown/binding-wasm32-wasi": "1.0.1",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+                "@rolldown/binding-win32-x64-msvc": "1.0.1"
             }
         },
         "node_modules/semver": {
@@ -2656,9 +2656,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-            "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2673,16 +2673,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.12",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-            "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+            "version": "8.0.13",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+            "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
                 "postcss": "^8.5.14",
-                "rolldown": "1.0.0",
+                "rolldown": "1.0.1",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "png-visual-compare",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "description": "Node.js utility to compare PNG files or their areas",
     "keywords": [
         "visual testing",
@@ -79,10 +79,10 @@
     },
     "devDependencies": {
         "@playwright/test": "~1.60.0",
-        "@types/node": "~25.7.0",
+        "@types/node": "~25.8.0",
         "@types/pngjs": "~6.0.5",
         "@vitest/coverage-v8": "~4.1.6",
-        "eslint": "~10.3.0",
+        "eslint": "~10.4.0",
         "prettier": "~3.8.3",
         "rimraf": "~6.1.3",
         "typescript": "~6.0.3",

--- a/src/ports/fsAsyncDiffWriter.ts
+++ b/src/ports/fsAsyncDiffWriter.ts
@@ -1,10 +1,26 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { mkdir, open } from 'node:fs/promises';
 import { parse } from 'node:path';
+import { PathValidationError } from '../errors';
 import type { AsyncDiffWriterPort } from './asyncTypes';
+
+const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
 export const fsAsyncDiffWriter: AsyncDiffWriterPort = {
     async write(path, data) {
         await mkdir(parse(path).dir, { recursive: true });
-        await writeFile(path, data);
+        try {
+            const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS);
+            try {
+                await handle.writeFile(data);
+            } finally {
+                await handle.close();
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+                throw new PathValidationError('Diff write refused: target path is a symlink (TOCTOU defence)');
+            }
+            throw error;
+        }
     },
 };

--- a/src/ports/fsDiffWriter.ts
+++ b/src/ports/fsDiffWriter.ts
@@ -1,4 +1,4 @@
-import { closeSync, constants as fsConstants, mkdirSync, openSync, writeSync } from 'node:fs';
+import { closeSync, constants as fsConstants, mkdirSync, openSync, writeFileSync } from 'node:fs';
 import { parse } from 'node:path';
 import { PathValidationError } from '../errors';
 import type { DiffWriterPort } from './types';
@@ -18,7 +18,7 @@ export const fsDiffWriter: DiffWriterPort = {
             throw error;
         }
         try {
-            writeSync(fd, data);
+            writeFileSync(fd, data);
         } finally {
             closeSync(fd);
         }

--- a/src/ports/fsDiffWriter.ts
+++ b/src/ports/fsDiffWriter.ts
@@ -1,10 +1,26 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { closeSync, constants as fsConstants, mkdirSync, openSync, writeSync } from 'node:fs';
 import { parse } from 'node:path';
+import { PathValidationError } from '../errors';
 import type { DiffWriterPort } from './types';
+
+const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
 export const fsDiffWriter: DiffWriterPort = {
     write(path, data) {
         mkdirSync(parse(path).dir, { recursive: true });
-        writeFileSync(path, data);
+        let fd: number;
+        try {
+            fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+                throw new PathValidationError('Diff write refused: target path is a symlink (TOCTOU defence)');
+            }
+            throw error;
+        }
+        try {
+            writeSync(fd, data);
+        } finally {
+            closeSync(fd);
+        }
     },
 };

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -51,7 +51,21 @@ export type ComparePngOptions = {
      * Absolute file path where the diff PNG is saved when mismatched pixels are found.
      * The directory is created automatically if it does not exist.
      * The file is **not** created when `pixelmatchResult === 0`.
+     *
+     * **Symlink-atomic write contract (SECU-03):**
+     * The diff is written through an `O_NOFOLLOW` open. If the final path component
+     * is a symlink at write-time, the write is refused with a {@link PathValidationError}
+     * and the symlink's target is never touched. This closes the TOCTOU window where
+     * a hostile process could plant a symlink between path validation and the write.
+     * Regular files at the target path continue to be overwritten as before — only
+     * the symlink-redirect attack is closed.
+     *
+     * **Residual scope:** the parent-directory race (a symlink planted in a parent
+     * component between validation and `mkdirSync(..., { recursive: true })`) is not
+     * yet closed; tracked as `SECU-09` in `BACKLOG.md`.
+     *
      * @default undefined (no diff file written)
+     * @throws {PathValidationError} if a symlink exists at the target path at write-time.
      */
     diffFilePath?: string;
     /**
@@ -120,9 +134,13 @@ export type ComparePngOptions = {
      * is caller-controlled to prevent arbitrary file writes via path traversal
      * (VUL-01: `../../etc/passwd`).
      *
-     * **Note:** This check is point-in-time; a race condition could allow a symlink
-     * to be created after validation. For critical security contexts, use OS-level
-     * chroot/jails or filesystem ACLs for defense-in-depth.
+     * **Note:** This containment check is point-in-time. The **target-path** race
+     * (a symlink planted at `diffFilePath` itself between validation and write) is
+     * closed at write-time via `O_NOFOLLOW` — see {@link ComparePngOptions.diffFilePath}
+     * and SECU-03. The **parent-directory** race (a symlink planted in a parent
+     * component between validation and `mkdir`) remains open and is tracked as
+     * SECU-09. For critical security contexts, use OS-level chroot/jails or
+     * filesystem ACLs for defense-in-depth.
      *
      * @default undefined (no containment enforced)
      * @example


### PR DESCRIPTION
## Summary

- **Closes the only open P1 in BACKLOG.md** — SECU-03. Both `fsDiffWriter` and `fsAsyncDiffWriter` now open `diffFilePath` with `O_NOFOLLOW`. A symlink planted between `validatePath` and the write is refused with `PathValidationError` instead of being followed; regular-file overwrite semantics are preserved.
- **Files SECU-09** — the residual parent-directory race (a symlink planted in a parent component between `validatePath` and `mkdirSync(recursive)`) is tracked as a follow-on (P2/Open).
- **Patch bump to `6.1.1`** — security tightening of an existing check; no public API surface change, no caller working today breaks unless they had a symlink at the target (which `validatePath` already rejects at validate-time).

## Design decisions (locked via `/grill-me`)

| # | Decision | Choice |
|---|---|---|
| 1 | TOCTOU primitive | `O_NOFOLLOW` (overwrite preserved) — not `wx`/`O_EXCL` |
| 2 | `ELOOP` handling | Wrap as `PathValidationError`; other open errors raw |
| 3 | Test design | Unit tests on each port + integration test via `comparePngWithPorts` |
| 4 | TSDoc scope | Update `diffFilePath` + amend `diffOutputBaseDir` cross-reference |
| 5 | Validate-time `lstat` check | Kept (defense in depth) |
| 6 | Parent-directory race | Deferred → SECU-09 |
| 7 | Partial-write cleanup | None (match Node stdlib) |
| 8 | Flag-constant DRY | Inline in each port |
| 9 | Version bump | Patch (`6.1.1`) |

Rationale for choosing `O_NOFOLLOW` over the backlog's original `wx` proposal: `wx` would refuse to overwrite any existing file — including legitimate regular files — turning every re-run of `comparePng` against a stable `diffFilePath` into a breaking change. `O_NOFOLLOW` closes the symlink-redirect attack (the actual threat SECU-03 describes) while preserving the overwrite-on-rerun pattern that CI consumers rely on.

## Changes

| File | Change |
|---|---|
| `src/ports/fsDiffWriter.ts` | `openSync` with `O_WRONLY\|O_CREAT\|O_TRUNC\|O_NOFOLLOW` + try/finally; ELOOP → `PathValidationError` |
| `src/ports/fsAsyncDiffWriter.ts` | Async mirror using `fs.promises.open` + FileHandle |
| `src/types/compare.options.ts` | TSDoc on `diffFilePath` (new `@throws PathValidationError`, symlink-refusal contract, residual parent-dir race note); TSDoc on `diffOutputBaseDir` clarifies which race is now closed |
| `__tests__/ports/fsDiffWriter.symlink.test.ts` | 7 cases: new file, overwrite preserved, 3 symlink shapes, EISDIR passthrough, message |
| `__tests__/ports/fsAsyncDiffWriter.symlink.test.ts` | Async mirror |
| `__tests__/comparePng.symlink-toctou.test.ts` | Integration: wrapper port plants symlink between validate and write; `PathValidationError` surfaces through `comparePngWithPorts`; sentinel byte-for-byte unchanged |
| `BACKLOG.md` | SECU-03 marked Done; SECU-09 added |
| `CHANGELOG.md` | `[6.1.1]` `### Security` entry |
| `CODEMAP.md` | Regenerated |
| `package.json` | `6.1.0 → 6.1.1` |
| `package.json` + `package-lock.json` | Also includes unrelated devDep refresh: `@types/node ~25.8.0`, `eslint ~10.4.0` |

## Test plan

- [x] `npm run test:unit` — 36/36 files, 372/372 tests, **100% coverage** on lines/functions/statements/branches
- [x] `lint`, `format:check`, `typecheck`, `test:license` — all clean (part of `test:unit` pretest chain)
- [x] Symlink TOCTOU tests run on macOS locally; Linux equivalent runs in CI
- [ ] CI matrix run (ubuntu + macos)
- [ ] Reviewer verifies the parent-directory race deferral in SECU-09 captures the residual scope adequately

## Behavioral contract

**Unchanged:**
- New `diffFilePath` writes succeed (regular file created)
- Existing regular files at `diffFilePath` are overwritten (this is the dominant CI usage pattern)
- Zero mismatched pixels → no write attempt

**Changed:**
- A symlink at `diffFilePath` at write-time → `PathValidationError` (previously: the write followed the symlink and overwrote the target). Affected callers are either (a) buggy — already rejected at validate-time by the existing `lstat` check — or (b) malicious, which is the attack class SECU-03 addresses.

## Residual scope (tracked in SECU-09)

The `mkdirSync(parse(path).dir, { recursive: true })` call before `open` can still cross a symlink planted in a parent component after `validatePath` runs. Tightening this requires per-segment `mkdir` + `lstat` and is intentionally deferred to keep this PR scoped to the target-path race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)