### PR TITLE
fix(security): close SECU-10/11/12 — three CTF findings

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -940,6 +940,122 @@ if (filePath.length > 4096) {
 - Coverage stays at 100 %
 - Symlink-in-parent test passes on Linux and macOS; Windows guarded as elsewhere
 
+## [SECU-10] Normalized canvas `maxPixels` check fires after extended buffers are already allocated
+
+**Priority:** P1  
+**Status:** Done  
+**Filed:** 2026-05-16 (CTF iteration 1). Closed in `feat/secu-10-11-12-ctf-findings` — check relocated into `normalizeImages` before `extendImage` is invoked; redundant check removed from `runComparison`.  
+**Problem:** SECU-02 specified that the canvas-level `maxPixels` check must fire **"after `maxWidth`/`maxHeight` are computed, before diff allocation"**, but the shipped implementation lives in `src/pipeline/runComparison.ts:8-14`. That check runs **after** `normalizeImages` returns, and `normalizeImages` has by then already called `extendImage(first, width, height)` and `extendImage(second, width, height)` (`src/pipeline/normalizeImages.ts:38-39`). Each `extendImage` call allocates a fresh `new PNG({ width, height, fill: true })` of the maxed-out canvas size and zero-fills its entire RGBA buffer. The `maxPixels` gate is meant to prevent exactly that allocation; placing it after the allocation makes the gate cosmetic for the DoS path it was designed to close.
+
+**Technical rationale (PoC under default options):** Both `getPngData` per-image guards pass for the following pair:
+
+- Image A: declared `16384 × 1024` (16,777,216 pixels — exactly `DEFAULT_MAX_PIXELS`, within `DEFAULT_MAX_DIMENSION = 16384`)
+- Image B: declared `1024 × 16384` (16,777,216 pixels — same)
+
+Then `normalizeImages` computes `width = 16384`, `height = 16384` and calls `extendImage` twice — each allocating a `16384 × 16384 × 4` ≈ **1 GiB** zero-filled buffer (~2 GiB peak across both sides) before `runComparison` finally throws `ResourceLimitError`. On a default-config host this is enough to OOM-kill the process or trigger heavy GC pressure. The defender has done the right thing on paper (the error message exists and the test `"rejects normalized canvas that exceeds maxPixels even when individual images do not"` passes) but the runtime allocation it was meant to prevent still happens.
+
+**Files to modify:**
+
+- `src/pipeline/normalizeImages.ts` — after computing `width = Math.max(width1, width2)` and `height = Math.max(height1, height2)` and **before** the `if (width1 !== width2 || height1 !== height2)` branch that calls `extendImage`, throw `ResourceLimitError` when `width * height > opts.maxPixels`. Use the existing error message format from `runComparison.ts:10-13` so the user-facing contract is unchanged.
+- `src/pipeline/runComparison.ts` — the existing check becomes defense-in-depth. Either delete it (preferred — the invariant is now upheld upstream) or annotate it with a comment that `normalizeImages` is the primary enforcement point and this is a redundant guard for direct callers of `runComparison` (none today).
+- `src/pipeline/normalizeImages.ts` — also: the check must guard the equal-size path too (`width = width1 = width2`, but still subject to `maxPixels`), so it must live outside the `if` branch.
+
+**Test additions in `__tests__/comparePng.exceptions.test.ts` (data-driven):**
+
+- `"rejects normalized canvas before allocating extended buffers"` — supply a pair `(16384×1024, 1024×16384)` with `maxPixels: 16_777_216` (the default). Spy on `PNG.prototype` constructor (or stub `extendImage` via a port if injection allows) and assert that `extendImage` is **not** invoked. Expected: `ResourceLimitError` with the existing canvas-overflow message.
+- `"runComparison maxPixels check no longer needed but remains as defense-in-depth"` — if the redundant check is kept, add a unit test for `runComparison.ts` that fabricates `NormalizedImages` with `width * height > maxPixels` directly (bypassing `normalizeImages`) and asserts the same `ResourceLimitError`. If the check is removed, delete that test.
+
+**Acceptance criteria:**
+
+- The PoC `(16384×1024, 1024×16384)` pair throws `ResourceLimitError` **without** allocating either extended canvas (verified via spy / call counter on `extendImage` or `PNG.bitblt`).
+- Existing `"rejects normalized canvas that exceeds maxPixels even when individual images do not"` test (from SECU-02) continues to pass with the same error code and message.
+- 100 % branch/line/function/statement coverage maintained.
+- Snapshot test suite unchanged byte-for-byte.
+- `docs/ARCHITECTURE.md` security section updated to reflect that the canvas-level check is enforced inside `normalizeImages`, not `runComparison`.
+
+**CTF notes:** This is a regression from the SECU-02 specification — the spec said "before diff allocation"; the implementation interpreted that as "before the diff `PNG` in `runComparison`" but missed that `extendImage` is itself a canvas-size allocation. The defect is purely a placement bug; the math, the error type, and the error message are all already correct.
+
+## [SECU-11] `validatePath` output mode leaks filesystem state for paths outside `baseDir`
+
+**Priority:** P2  
+**Status:** Done  
+**Filed:** 2026-05-16 (CTF iteration 2). Closed in `feat/secu-10-11-12-ctf-findings` — lstat/stat shape checks reordered to run **after** the `baseDir` containment check via the new `assertOutputTargetShape` helper.  
+**Problem:** In `src/validatePath.ts:86-104`, the **symlink-at-target** check (`lstatSync(resolved).isSymbolicLink()`) and the **existing-directory** check (`statSync(resolved).isDirectory()`) execute unconditionally for `mode === 'output'`, **before** the `baseDir` containment check at line 105-119. As a result, an attacker who controls `diffFilePath` while `diffOutputBaseDir` is enforced can use `validatePath` as a probing oracle for arbitrary absolute paths anywhere on the filesystem — even though those paths would ultimately be rejected by the containment check.
+
+**Probe walkthrough (assume `diffOutputBaseDir = '/srv/runs/job-42'`):**
+
+| Attacker's `diffFilePath`       | Filesystem state                | Error message returned                                             | Information leaked                                                                       |
+| ------------------------------- | ------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `/etc/ssh/ssh_host_ed25519_key` | Regular file, exists            | `Path traversal detected: "/etc/..." is outside ...`               | (none — containment fires, expected)                                                     |
+| `/var/secrets/api-token`        | **Symlink** pointing to a vault | `Invalid file path: output path must not be an existing symlink`   | The path exists **and** it is a symlink (confirms a vault indirection at that location). |
+| `/var/log`                      | **Directory**, exists           | `Invalid file path: output path must not be an existing directory` | The path exists **and** it is a directory.                                               |
+| `/etc/totally-not-here-9923`    | ENOENT                          | `Path traversal detected: "/etc/..." is outside ...`               | (none — both checks skip cleanly, containment fires)                                     |
+
+The attacker iterates over candidate paths and reads back distinct error strings; the response splits the universe of probed paths into three observable classes — _exists-symlink_, _exists-directory_, and _anything else_. Combined with knowledge of common filesystem layouts (`/var/secrets/<service>`, `/etc/ssh/host_*`, `/proc/<pid>`, container mount points) this constitutes a generic filesystem-enumeration primitive. The library's own `getPngData.ts:96` comment already cites VUL-05 ("prevents filesystem enumeration") as the reason for the unified "source could not be loaded" message on input paths — the output-side check missed the same lesson.
+
+**Technical rationale:** The early existence checks make sense **inside** the trust boundary (a caller writing to `/srv/runs/job-42/diff.png` legitimately wants to know "don't overwrite that symlink"). They make no sense **outside** the boundary, where they answer questions the attacker shouldn't be allowed to ask. The fix is purely an ordering change: run the cheap lexical containment check first, then realpath-based containment, and only then run the symlink/directory existence checks against the (now-confirmed-in-bounds) target.
+
+**Files to modify:**
+
+- `src/validatePath.ts` — reorder the body so that, when `baseDir !== undefined`, the lexical `isContained` and realpath-based containment checks run **before** the `lstatSync` / `statSync` block. When `baseDir === undefined` (legacy, anywhere-on-disk) the existence checks remain first (no oracle to exploit because no boundary is being enforced). Suggested refactor: extract a `assertOutputTargetShape(resolved): void` helper containing the lstat/statSync block, then call it after the containment block.
+- TSDoc on `validatePath` — clarify that, with `baseDir` enforced, paths outside the boundary always yield `Path traversal detected: …` and never reveal filesystem state at the probed location.
+
+**Test additions in `__tests__/validatePath.test.ts`:**
+
+- `"with diffOutputBaseDir set, an out-of-bounds symlink target reports traversal — not 'must not be a symlink'"` — create a symlink at `/tmp/outside-XXXX/leak-link`, set `baseDir = /tmp/inside-XXXX`, assert the thrown `PathValidationError.message` starts with `Path traversal detected:` and never contains the strings `symlink` or `directory`.
+- `"with diffOutputBaseDir set, an out-of-bounds existing directory reports traversal — not 'must not be a directory'"` — analogous case with a directory target outside `baseDir`.
+- `"without baseDir, existing-symlink and existing-directory checks are unchanged"` — regression guard for the legacy code path.
+
+**Acceptance criteria:**
+
+- When `baseDir` is set, the error message returned for any path outside `baseDir` is identical regardless of whether the out-of-bounds path is a regular file, a symlink, a directory, or absent.
+- The two existing positive paths — "writing a new file inside `baseDir`" and "writing under a deep `baseDir` whose parents include a symlink the validator follows" — continue to work.
+- Coverage remains at 100 %.
+- `docs/ARCHITECTURE.md` security section gains a sentence documenting the new ordering invariant.
+
+**CTF notes:** This pairs with the inline comment in `getPngData.ts:95-97` and `getPngData.ts:113-115` that explicitly cites VUL-05 ("prevents filesystem enumeration") — the input-side enforces a uniform error message, but the output-side leaks a three-way oracle. Two-way fix: tighten output-side ordering **and** add a similar VUL-05-style comment so the invariant is documented at the call site.
+
+## [SECU-12] Diff PNG is written with default `0o666 & ~umask` — world-readable on a default Linux host
+
+**Priority:** P2  
+**Status:** Done  
+**Filed:** 2026-05-16 (CTF iteration 3). Closed in `feat/secu-10-11-12-ctf-findings` — both writers now pass an explicit `0o600` mode to `openSync` / `open`.  
+**Problem:** Both `src/ports/fsDiffWriter.ts:13` and `src/ports/fsAsyncDiffWriter.ts:13` open the diff target with `openSync(path, SYMLINK_REFUSING_WRITE_FLAGS)` / `await open(path, SYMLINK_REFUSING_WRITE_FLAGS)` and pass **no third `mode` argument**. When `O_CREAT` is one of the flags (it is — `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW`), POSIX `open(2)` creates the file with mode `0o666 & ~umask`. On a default Linux host (`umask 0022`) that yields `0o644` (`rw-r--r--`) — i.e. **world-readable**. The diff PNG can contain visual evidence of whatever the consumer was screenshotting — production dashboards, JWTs in browser dev-tools, half-loaded admin pages — and every local user can read it.
+
+**Threat model:**
+
+- Multi-tenant CI runners (shared Linux hosts where one job's diff artefact is readable by another job running concurrently as a different uid).
+- Self-hosted GitHub runner / GitLab runner / Jenkins agent boxes with multiple users (developers SSH-ing in) and a single shared `/tmp` or repo workdir.
+- Developer workstations that run untrusted helper scripts under separate uids (rarely, but the same `~/.npm/_cacache/_locks` pattern keeps biting because of permissive umask).
+- The diff path itself is usually outside `diffOutputBaseDir` only via misconfiguration, but the **mode** at the target is independent of containment — even a containment-respecting write leaks.
+
+**Why the current code looks safe but isn't:** SECU-03 closed the symlink-redirect TOCTOU at the target by switching from `writeFileSync` to a low-level `openSync` + `O_NOFOLLOW` flow. That refactor was the right call — but it also changed the file-creation contract. `writeFileSync(path, data)` (Node 20+) defaults to mode `0o666` _too_ — so the regression is technically pre-existing — but the switch to `openSync` made it _explicit_ in the source while still inheriting umask. The opportunity to thread an explicit mode was right there and wasn't taken.
+
+**Files to modify:**
+
+- `src/ports/fsDiffWriter.ts` — change `openSync(path, SYMLINK_REFUSING_WRITE_FLAGS)` to `openSync(path, SYMLINK_REFUSING_WRITE_FLAGS, 0o600)`.
+- `src/ports/fsAsyncDiffWriter.ts` — change `open(path, SYMLINK_REFUSING_WRITE_FLAGS)` to `open(path, SYMLINK_REFUSING_WRITE_FLAGS, 0o600)`.
+- `src/types/compare.options.ts` — extend the `diffFilePath` TSDoc with a "**File mode contract:**" paragraph: "The diff is created with mode `0o600` (owner read/write only). This intentionally bypasses umask so that diffs do not become group- or world-readable on default Linux hosts. To override this, inject a custom `diffWriter` port via `comparePngWithPorts` (SECU-07 will make this ergonomic once ports are part of the public barrel)."
+- `docs/ARCHITECTURE.md` — security model section: list "diff-file mode" alongside "diff-write symlink safety".
+
+**Alternative considered and rejected:** Inheriting umask "to match POSIX convention". Rejected because (a) the rest of the library treats umask as an unsafe default (validatePath rejects symlinks by default; the path canonicalization assumes adversarial neighbours); (b) callers who genuinely want world-readable diffs are a vanishing minority and can express it via a custom `DiffWriterPort`, while callers who get burned by world-readable diffs cannot recover the leaked bytes; (c) `0o600` matches the behaviour of `fs.mkdtemp` family (which always returns mode `0o700`) — the precedent inside Node's own stdlib favours private-by-default for synthesised filesystem objects.
+
+**Test additions:**
+
+- `__tests__/ports/fsDiffWriter.mode.test.ts` (new) — write a diff to a tmp directory under a deliberately permissive umask (`process.umask(0o000)`) and `fs.statSync(path).mode & 0o777` must equal `0o600`. Restore previous umask in `afterEach`. Linux/macOS only; Windows-guard.
+- `__tests__/ports/fsAsyncDiffWriter.mode.test.ts` (new) — same assertion on the async path.
+- Existing snapshot tests must continue to produce byte-identical PNG content (mode change is metadata-only).
+
+**Acceptance criteria:**
+
+- Diff files created by either writer have mode `0o600` regardless of the process umask, on Linux and macOS.
+- Windows behaviour is unchanged (Windows ignores POSIX mode bits — Node ports the value but the filesystem doesn't honour it; the test must skip rather than fail).
+- 100 % coverage maintained.
+- TSDoc on `diffFilePath` documents the mode contract.
+- A short paragraph appears in `docs/ARCHITECTURE.md` security section.
+
+**CTF notes:** Discovered by reading `openSync` calls for missing third arguments. Smallest possible fix (one literal per writer) with the largest possible blast-radius reduction — every prior release of this package has shipped diff files at the host's umask default, and the documentation has never warned consumers about it.
+
 ## [PERF-04] Skip eager clone in `normalizeImages` when no mutation follows
 
 **Priority:** P2  

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.1.1"
     },
-    "sourceHash": "4673016f4f19362202d139f68a524fc9c15c6c60991faa85bb8d16fa4d2b5df3",
+    "sourceHash": "714454209099df64be148639a8651f9eba43a8f4877280ec24403f39b5851b76",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -1037,7 +1037,7 @@ Schema: `codemap.v2`
                 {
                     "name": "clonePng",
                     "kind": "function",
-                    "line": 8,
+                    "line": 9,
                     "exported": false,
                     "signature": "function clonePng(image: PNGWithMetadata): PNGWithMetadata",
                     "members": null,
@@ -1046,7 +1046,7 @@ Schema: `codemap.v2`
                 {
                     "name": "toComparablePng",
                     "kind": "function",
-                    "line": 14,
+                    "line": 15,
                     "exported": false,
                     "signature": "function toComparablePng(source: LoadedPng): PNGWithMetadata",
                     "members": null,
@@ -1055,7 +1055,7 @@ Schema: `codemap.v2`
                 {
                     "name": "normalizeImages",
                     "kind": "function",
-                    "line": 23,
+                    "line": 24,
                     "exported": true,
                     "signature": "export function normalizeImages(sources: LoadedSources, opts: ResolvedOptions): NormalizedImages",
                     "members": null,
@@ -1064,6 +1064,7 @@ Schema: `codemap.v2`
             ],
             "imports": [
                 "../addColoredAreasToImage",
+                "../errors",
                 "../extendImage",
                 "../fillImageSizeDifference",
                 "../types/png.data",
@@ -1143,7 +1144,7 @@ Schema: `codemap.v2`
                 {
                     "name": "runComparison",
                     "kind": "function",
-                    "line": 7,
+                    "line": 10,
                     "exported": true,
                     "signature": "export function runComparison(images: NormalizedImages, opts: ResolvedOptions): ComparisonResult",
                     "members": null,
@@ -1152,7 +1153,6 @@ Schema: `codemap.v2`
             ],
             "imports": [
                 "../adapters/toPixelmatchOptions",
-                "../errors",
                 "./types",
                 "pixelmatch",
                 "pngjs"
@@ -1261,11 +1261,20 @@ Schema: `codemap.v2`
                     "jsdoc": null
                 },
                 {
+                    "name": "DIFF_FILE_MODE",
+                    "kind": "const",
+                    "line": 12,
+                    "exported": false,
+                    "signature": "const DIFF_FILE_MODE = 0o600",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
                     "name": "fsAsyncDiffWriter",
                     "kind": "const",
-                    "line": 9,
+                    "line": 14,
                     "exported": true,
-                    "signature": "export const fsAsyncDiffWriter: AsyncDiffWriterPort = { async write(path, data) { await mkdir(parse(path).dir, { recursive: true }); try { const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS)…",
+                    "signature": "export const fsAsyncDiffWriter: AsyncDiffWriterPort = { async write(path, data) { await mkdir(parse(path).dir, { recursive: true }); try { const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS,…",
                     "members": null,
                     "jsdoc": null
                 }
@@ -1314,11 +1323,20 @@ Schema: `codemap.v2`
                     "jsdoc": null
                 },
                 {
+                    "name": "DIFF_FILE_MODE",
+                    "kind": "const",
+                    "line": 11,
+                    "exported": false,
+                    "signature": "const DIFF_FILE_MODE = 0o600",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
                     "name": "fsDiffWriter",
                     "kind": "const",
-                    "line": 8,
+                    "line": 13,
                     "exported": true,
-                    "signature": "export const fsDiffWriter: DiffWriterPort = { write(path, data) { mkdirSync(parse(path).dir, { recursive: true }); let fd: number; try { fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS); } catch (err…",
+                    "signature": "export const fsDiffWriter: DiffWriterPort = { write(path, data) { mkdirSync(parse(path).dir, { recursive: true }); let fd: number; try { fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS, DIFF_FILE_MOD…",
                     "members": null,
                     "jsdoc": null
                 }
@@ -1644,9 +1662,18 @@ Schema: `codemap.v2`
                     "jsdoc": null
                 },
                 {
+                    "name": "assertOutputTargetShape",
+                    "kind": "function",
+                    "line": 61,
+                    "exported": false,
+                    "signature": "function assertOutputTargetShape(resolved: string): void",
+                    "members": null,
+                    "jsdoc": "Asserts that an output-mode target is not an existing symlink or directory."
+                },
+                {
                     "name": "validatePath",
                     "kind": "function",
-                    "line": 77,
+                    "line": 116,
                     "exported": true,
                     "signature": "export function validatePath(filePath: string, baseDir?: string, mode: ValidatePathMode = 'output'): ValidatedPath",
                     "members": null,

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.1.1"
     },
-    "sourceHash": "714454209099df64be148639a8651f9eba43a8f4877280ec24403f39b5851b76",
+    "sourceHash": "274c3e0094a7b3a29110ff285204146c3676a99284a69853038bc2da116ac4be",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -1263,7 +1263,7 @@ Schema: `codemap.v2`
                 {
                     "name": "DIFF_FILE_MODE",
                     "kind": "const",
-                    "line": 12,
+                    "line": 18,
                     "exported": false,
                     "signature": "const DIFF_FILE_MODE = 0o600",
                     "members": null,
@@ -1272,7 +1272,7 @@ Schema: `codemap.v2`
                 {
                     "name": "fsAsyncDiffWriter",
                     "kind": "const",
-                    "line": 14,
+                    "line": 20,
                     "exported": true,
                     "signature": "export const fsAsyncDiffWriter: AsyncDiffWriterPort = { async write(path, data) { await mkdir(parse(path).dir, { recursive: true }); try { const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS,…",
                     "members": null,
@@ -1325,7 +1325,7 @@ Schema: `codemap.v2`
                 {
                     "name": "DIFF_FILE_MODE",
                     "kind": "const",
-                    "line": 11,
+                    "line": 17,
                     "exported": false,
                     "signature": "const DIFF_FILE_MODE = 0o600",
                     "members": null,
@@ -1334,7 +1334,7 @@ Schema: `codemap.v2`
                 {
                     "name": "fsDiffWriter",
                     "kind": "const",
-                    "line": 13,
+                    "line": 19,
                     "exported": true,
                     "signature": "export const fsDiffWriter: DiffWriterPort = { write(path, data) { mkdirSync(parse(path).dir, { recursive: true }); let fd: number; try { fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS, DIFF_FILE_MOD…",
                     "members": null,

--- a/__tests__/pipeline/normalizeImages.test.ts
+++ b/__tests__/pipeline/normalizeImages.test.ts
@@ -1,9 +1,11 @@
 import { Buffer } from 'node:buffer';
-import { PNG } from 'pngjs';
+import { PNG, type PNGWithMetadata } from 'pngjs';
 import { describe, expect, test } from 'vitest';
+import { ResourceLimitError } from '../../src/errors';
 import { loadSources } from '../../src/pipeline/loadSources';
 import { normalizeImages } from '../../src/pipeline/normalizeImages';
 import { resolveOptions } from '../../src/pipeline/resolveOptions';
+import type { LoadedSources } from '../../src/pipeline/types';
 
 describe('normalizeImages', () => {
     test('returns new images without mutating the loaded source PNGs', () => {
@@ -31,5 +33,44 @@ describe('normalizeImages', () => {
         expect(Array.from(sources.first.png.data.subarray(0, 4))).toEqual(firstOriginalPixel);
         expect(Array.from(normalized.first.data.subarray(0, 4))).toEqual([0, 0, 255, 255]);
         expect(Array.from(normalized.first.data.subarray(4, 8))).toEqual([0, 255, 0, 255]);
+    });
+});
+
+describe('normalizeImages — SECU-10 canvas maxPixels guard owned by normalizeImages, not runComparison', () => {
+    test('throws ResourceLimitError directly from normalizeImages when canvas exceeds maxPixels (100×1 + 1×100, maxPixels=100)', () => {
+        // 100×1 + 1×100 inputs each have 100 pixels (within maxPixels=100), but the
+        // normalized canvas would be 100×100 = 10 000 pixels. Pre-fix this throw
+        // came from `runComparison`, *after* `normalizeImages` had already returned
+        // (and `extendImage` had already allocated two oversized buffers). Post-fix
+        // the throw must come from `normalizeImages` itself — verified here by
+        // invoking it directly and asserting the throw, without ever calling
+        // `runComparison`.
+        const wide = new PNG({ width: 100, height: 1, fill: true });
+        const tall = new PNG({ width: 1, height: 100, fill: true });
+        const opts = resolveOptions({ maxDimension: 1000, maxPixels: 100 });
+        const sources = loadSources(PNG.sync.write(wide), PNG.sync.write(tall), opts);
+
+        expect(() => normalizeImages(sources, opts)).toThrow(ResourceLimitError);
+        expect(() => normalizeImages(sources, opts)).toThrow(
+            /Normalized canvas pixel count \(10000\) exceeds the maximum allowed 100 pixels/,
+        );
+    });
+
+    test('throws on the same-size path too (guard lives outside the size-difference branch)', () => {
+        // Same-size inputs skip the `if (width1 !== width2 || ...)` branch entirely,
+        // so the guard must live outside that branch to be reached. We construct
+        // `LoadedSources` directly so the per-image check in `getPngData` does not
+        // intercept first — this isolates the responsibility we care about here.
+        const sameSizePng = new PNG({ width: 10, height: 10, fill: true });
+        const opts = resolveOptions({ maxPixels: 50 });
+        const sources: LoadedSources = {
+            png1: PNG.sync.write(sameSizePng),
+            png2: PNG.sync.write(sameSizePng),
+            first: { kind: 'valid', png: sameSizePng as unknown as PNGWithMetadata },
+            second: { kind: 'valid', png: sameSizePng as unknown as PNGWithMetadata },
+        };
+
+        expect(() => normalizeImages(sources, opts)).toThrow(ResourceLimitError);
+        expect(() => normalizeImages(sources, opts)).toThrow(/Normalized canvas pixel count \(100\) exceeds the maximum allowed 50 pixels/);
     });
 });

--- a/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
@@ -86,3 +86,33 @@ describe('fsAsyncDiffWriter symlink refusal (SECU-03)', () => {
         expect(existsSync(forbidden)).toBe(false);
     });
 });
+
+describe('fsAsyncDiffWriter file mode (SECU-12)', () => {
+    const rootDir = path.resolve('./test-results/fs-async-diff-writer-mode');
+    const target = path.join(rootDir, 'diff.png');
+    const payload = Buffer.from('PNG-PAYLOAD-BYTES');
+    let previousUmask = 0;
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(rootDir, { recursive: true });
+        // Force a deliberately permissive umask so any reliance on umask would
+        // yield a mode wider than 0o600 (e.g. 0o666). The explicit mode passed
+        // to open() must override it.
+        previousUmask = process.umask(0o000);
+    });
+
+    afterEach(() => {
+        process.umask(previousUmask);
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('creates diff files with mode 0o600 regardless of permissive umask', async () => {
+        if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
+
+        await fsAsyncDiffWriter.write(asValidatedPath(target), payload);
+
+        const mode = lstatSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+});

--- a/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsAsyncDiffWriter.symlink.test.ts
@@ -96,9 +96,13 @@ describe('fsAsyncDiffWriter file mode (SECU-12)', () => {
     beforeEach(() => {
         rmSync(rootDir, { recursive: true, force: true });
         mkdirSync(rootDir, { recursive: true });
-        // Force a deliberately permissive umask so any reliance on umask would
-        // yield a mode wider than 0o600 (e.g. 0o666). The explicit mode passed
-        // to open() must override it.
+        // Set umask(0) so the kernel's `mode & ~umask` masking leaves the
+        // requested create-mode untouched; the resulting mode we observe is
+        // then a direct function of what the writer requested rather than a
+        // combination of mode + umask. The asymmetry only goes one way: a
+        // restrictive umask can narrow permissions, but a permissive umask
+        // can never widen them past the requested mode — and the explicit
+        // handle.chmod the writer issues makes both directions irrelevant.
         previousUmask = process.umask(0o000);
     });
 
@@ -107,12 +111,28 @@ describe('fsAsyncDiffWriter file mode (SECU-12)', () => {
         rmSync(rootDir, { recursive: true, force: true });
     });
 
-    test('creates diff files with mode 0o600 regardless of permissive umask', async () => {
+    test('creates new diff files with mode 0o600 under a permissive umask', async () => {
         if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
 
         await fsAsyncDiffWriter.write(asValidatedPath(target), payload);
 
         const mode = lstatSync(target).mode & 0o777;
         expect(mode).toBe(0o600);
+    });
+
+    test('tightens the mode of a pre-existing 0o644 file on overwrite (handle.chmod, not just open-mode)', async () => {
+        if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
+
+        // Pre-create the target with a wider mode, as if a previous version of
+        // the library (or any other tool) had written it. `O_TRUNC` truncates
+        // bytes but POSIX does NOT change the inode's mode; without the
+        // post-open handle.chmod the file would stay at 0o644.
+        writeFileSync(target, 'stale-bytes', { mode: 0o644 });
+        expect(lstatSync(target).mode & 0o777).toBe(0o644);
+
+        await fsAsyncDiffWriter.write(asValidatedPath(target), payload);
+
+        expect(lstatSync(target).mode & 0o777).toBe(0o600);
+        expect(readFileSync(target)).toEqual(payload);
     });
 });

--- a/__tests__/ports/fsDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsDiffWriter.symlink.test.ts
@@ -111,3 +111,33 @@ describe('fsDiffWriter symlink refusal (SECU-03)', () => {
         expect(existsSync(forbidden)).toBe(false);
     });
 });
+
+describe('fsDiffWriter file mode (SECU-12)', () => {
+    const rootDir = path.resolve('./test-results/fs-diff-writer-mode');
+    const target = path.join(rootDir, 'diff.png');
+    const payload = Buffer.from('PNG-PAYLOAD-BYTES');
+    let previousUmask = 0;
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(rootDir, { recursive: true });
+        // Force a deliberately permissive umask so any reliance on umask would
+        // yield a mode wider than 0o600 (e.g. 0o666). The explicit mode passed
+        // to openSync must override it.
+        previousUmask = process.umask(0o000);
+    });
+
+    afterEach(() => {
+        process.umask(previousUmask);
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('creates diff files with mode 0o600 regardless of permissive umask', () => {
+        if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
+
+        fsDiffWriter.write(asValidatedPath(target), payload);
+
+        const mode = lstatSync(target).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+});

--- a/__tests__/ports/fsDiffWriter.symlink.test.ts
+++ b/__tests__/ports/fsDiffWriter.symlink.test.ts
@@ -121,9 +121,13 @@ describe('fsDiffWriter file mode (SECU-12)', () => {
     beforeEach(() => {
         rmSync(rootDir, { recursive: true, force: true });
         mkdirSync(rootDir, { recursive: true });
-        // Force a deliberately permissive umask so any reliance on umask would
-        // yield a mode wider than 0o600 (e.g. 0o666). The explicit mode passed
-        // to openSync must override it.
+        // Set umask(0) so the kernel's `mode & ~umask` masking leaves the
+        // requested create-mode untouched; the resulting mode we observe is
+        // then a direct function of what the writer requested rather than a
+        // combination of mode + umask. The asymmetry only goes one way: a
+        // restrictive umask can narrow permissions, but a permissive umask
+        // can never widen them past the requested mode — and the explicit
+        // fchmod the writer issues makes both directions irrelevant.
         previousUmask = process.umask(0o000);
     });
 
@@ -132,12 +136,28 @@ describe('fsDiffWriter file mode (SECU-12)', () => {
         rmSync(rootDir, { recursive: true, force: true });
     });
 
-    test('creates diff files with mode 0o600 regardless of permissive umask', () => {
+    test('creates new diff files with mode 0o600 under a permissive umask', () => {
         if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
 
         fsDiffWriter.write(asValidatedPath(target), payload);
 
         const mode = lstatSync(target).mode & 0o777;
         expect(mode).toBe(0o600);
+    });
+
+    test('tightens the mode of a pre-existing 0o644 file on overwrite (fchmod, not just open-mode)', () => {
+        if (process.platform === 'win32') return; // Windows does not honour POSIX mode bits.
+
+        // Pre-create the target with a wider mode, as if a previous version of
+        // the library (or any other tool) had written it. `O_TRUNC` truncates
+        // bytes but POSIX does NOT change the inode's mode; without the
+        // post-open fchmod the file would stay at 0o644.
+        writeFileSync(target, 'stale-bytes', { mode: 0o644 });
+        expect(lstatSync(target).mode & 0o777).toBe(0o644);
+
+        fsDiffWriter.write(asValidatedPath(target), payload);
+
+        expect(lstatSync(target).mode & 0o777).toBe(0o600);
+        expect(readFileSync(target)).toEqual(payload);
     });
 });

--- a/__tests__/validatePath.symlinks.test.ts
+++ b/__tests__/validatePath.symlinks.test.ts
@@ -102,3 +102,99 @@ describe('validatePath symlink containment', () => {
         );
     });
 });
+
+describe('validatePath — SECU-11 out-of-bounds shape checks never leak filesystem state', () => {
+    // When `baseDir` is set, every path *outside* `baseDir` must surface as
+    // "Path traversal detected: …" — never as "must not be an existing symlink"
+    // or "must not be an existing directory". The early-existence checks
+    // formerly leaked a three-way oracle (exists-symlink / exists-directory /
+    // anything-else) for arbitrary absolute paths.
+    const rootDir = path.resolve('./test-results/validate-path-secu-11');
+    const baseDir = path.join(rootDir, 'base');
+    const outsideDir = path.join(rootDir, 'outside');
+    const outsideRegularFile = path.join(outsideDir, 'target.txt');
+    const outsideSymlink = path.join(outsideDir, 'target-link');
+    const outsideExistingDir = path.join(outsideDir, 'a-real-directory');
+
+    beforeEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+        mkdirSync(baseDir, { recursive: true });
+        mkdirSync(outsideDir, { recursive: true });
+        mkdirSync(outsideExistingDir, { recursive: true });
+        writeFileSync(outsideRegularFile, 'sentinel');
+    });
+
+    afterEach(() => {
+        rmSync(rootDir, { recursive: true, force: true });
+    });
+
+    test('an out-of-bounds existing symlink reports traversal — never "must not be an existing symlink"', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        symlinkSync(outsideRegularFile, outsideSymlink);
+
+        try {
+            validatePath(outsideSymlink, baseDir, 'output');
+            throw new Error('Expected validatePath to throw');
+        } catch (error) {
+            expect(error).toBeInstanceOf(PathValidationError);
+            const message = (error as Error).message;
+            expect(message).toContain('Path traversal detected');
+            // Must not leak the shape-check phrases that would distinguish
+            // "exists-symlink" / "exists-directory" / "anything-else" outcomes.
+            expect(message).not.toContain('must not be an existing symlink');
+            expect(message).not.toContain('must not be an existing directory');
+        }
+    });
+
+    test('an out-of-bounds existing directory reports traversal — never "must not be an existing directory"', () => {
+        try {
+            validatePath(outsideExistingDir, baseDir, 'output');
+            throw new Error('Expected validatePath to throw');
+        } catch (error) {
+            expect(error).toBeInstanceOf(PathValidationError);
+            const message = (error as Error).message;
+            expect(message).toContain('Path traversal detected');
+            expect(message).not.toContain('must not be an existing directory');
+            expect(message).not.toContain('must not be an existing symlink');
+        }
+    });
+
+    test('an out-of-bounds regular file reports traversal (regression guard for non-shape paths)', () => {
+        try {
+            validatePath(outsideRegularFile, baseDir, 'output');
+            throw new Error('Expected validatePath to throw');
+        } catch (error) {
+            expect(error).toBeInstanceOf(PathValidationError);
+            expect((error as Error).message).toContain('Path traversal detected');
+        }
+    });
+
+    test('an in-bounds existing symlink still surfaces the shape error (legacy contract preserved inside the boundary)', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        const insideSymlink = path.join(baseDir, 'inside-link');
+        symlinkSync(outsideRegularFile, insideSymlink);
+
+        expectPathValidationError(() => validatePath(insideSymlink, baseDir, 'output'), 'output path must not be an existing symlink');
+    });
+
+    test('an in-bounds existing directory still surfaces the shape error (legacy contract preserved inside the boundary)', () => {
+        const insideDir = path.join(baseDir, 'inside-dir');
+        mkdirSync(insideDir);
+
+        expectPathValidationError(() => validatePath(insideDir, baseDir, 'output'), 'output path must not be an existing directory');
+    });
+
+    test('without baseDir, the legacy shape-check-first behaviour is preserved (no oracle exists either way)', () => {
+        if (process.platform === 'win32') return; // TODO: add Windows symlink coverage.
+
+        symlinkSync(outsideRegularFile, outsideSymlink);
+
+        expectPathValidationError(() => validatePath(outsideSymlink, undefined, 'output'), 'output path must not be an existing symlink');
+        expectPathValidationError(
+            () => validatePath(outsideExistingDir, undefined, 'output'),
+            'output path must not be an existing directory',
+        );
+    });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,7 @@ Responsibilities:
 - clones valid decoded PNGs before mutation
 - turns one-sided invalid inputs into comparable `0×0` canvases
 - paints `excludedAreas` on both images
+- enforces `maxPixels` on the normalized comparison canvas (SECU-10), **before** any extension allocates oversized buffers
 - extends both images to `max(width) × max(height)`
 - paints padded regions with `extendedAreaColor`
 
@@ -128,10 +129,11 @@ Important invariant: normalization returns **new images** and does not mutate de
 
 Responsibilities:
 
-- enforces `maxPixels` on the normalized comparison canvas
 - lazily allocates a diff image only when diff output is requested
 - converts public `pixelmatchOptions` through `toPixelmatchOptions(...)`
 - calls `pixelmatch(...)`
+
+> The normalized-canvas `maxPixels` guard lives in `normalizeImages` (SECU-10), not here — the check must fire **before** `extendImage` allocates its target buffers.
 
 ### 5. `persistDiff`
 
@@ -180,6 +182,18 @@ The validator:
     - existing output directories
     - existing output symlinks
 - permits not-yet-created output parent directories by validating the nearest existing ancestor
+
+> **Check ordering (SECU-11):** when `baseDir` is set, the lexical and realpath containment checks run **before** the output-mode symlink/directory shape checks. As a consequence, every out-of-bounds path surfaces as a uniform `Path traversal detected: …` error and never as `must not be an existing symlink/directory` — closing a filesystem-enumeration oracle for paths outside the security boundary.
+
+### Diff write contract
+
+`src/ports/fsDiffWriter.ts`, `src/ports/fsAsyncDiffWriter.ts`
+
+The diff write:
+
+- creates parent directories on demand via `mkdir(..., { recursive: true })` (parent-component race tracked as SECU-09)
+- opens the target with `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW` (target-component symlink race closed by SECU-03)
+- passes an explicit POSIX mode `0o600` (SECU-12) so diff files are owner-only regardless of the process umask
 
 ### Area validation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,7 +193,7 @@ The diff write:
 
 - creates parent directories on demand via `mkdir(..., { recursive: true })` (parent-component race tracked as SECU-09)
 - opens the target with `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW` (target-component symlink race closed by SECU-03)
-- passes an explicit POSIX mode `0o600` (SECU-12) so diff files are owner-only regardless of the process umask
+- passes an explicit POSIX create-mode `0o600` to `open` and then issues an explicit `fchmod(0o600)` on the open handle (SECU-12). The `open` mode alone is insufficient: POSIX masks it with `~umask` (a restrictive umask can only narrow it further, never widen it) and `O_TRUNC` does not reset the mode of a pre-existing file. The post-open `fchmod` makes the final mode `0o600` in both the create and overwrite cases.
 
 ### Area validation
 

--- a/src/pipeline/normalizeImages.ts
+++ b/src/pipeline/normalizeImages.ts
@@ -1,5 +1,6 @@
 import { PNG, type PNGWithMetadata } from 'pngjs';
 import { addColoredAreasToImage } from '../addColoredAreasToImage';
+import { ResourceLimitError } from '../errors';
 import { extendImage } from '../extendImage';
 import { fillImageSizeDifference } from '../fillImageSizeDifference';
 import type { LoadedPng } from '../types/png.data';
@@ -33,6 +34,18 @@ export function normalizeImages(sources: LoadedSources, opts: ResolvedOptions): 
     const { width: width2, height: height2 } = second;
     const width = Math.max(width1, width2);
     const height = Math.max(height1, height2);
+
+    // SECU-10: enforce the normalized-canvas pixel cap *before* extendImage allocates
+    // its target buffers. Allowing `extendImage` to run first would let a crafted
+    // (16384×1024, 1024×16384) input pair allocate ~2 GiB of zero-filled RGBA buffers
+    // before the runtime guard could throw.
+    const pixelCount = width * height;
+    if (pixelCount > opts.maxPixels) {
+        throw new ResourceLimitError(
+            `Normalized canvas pixel count (${pixelCount}) exceeds the maximum allowed ${opts.maxPixels} pixels. ` +
+                'Set opts.maxPixels to increase the limit.',
+        );
+    }
 
     if (width1 !== width2 || height1 !== height2) {
         first = extendImage(first, width, height);

--- a/src/pipeline/runComparison.ts
+++ b/src/pipeline/runComparison.ts
@@ -1,18 +1,13 @@
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 import { toPixelmatchOptions } from '../adapters/toPixelmatchOptions';
-import { ResourceLimitError } from '../errors';
 import type { ComparisonResult, NormalizedImages, ResolvedOptions } from './types';
 
+// SECU-10: the normalized-canvas `maxPixels` guard is now enforced inside
+// `normalizeImages`, *before* `extendImage` allocates oversized RGBA buffers.
+// By the time we reach this function, `images.width * images.height` is already
+// known to be within `opts.maxPixels`.
 export function runComparison(images: NormalizedImages, opts: ResolvedOptions): ComparisonResult {
-    const pixelCount = images.width * images.height;
-    if (pixelCount > opts.maxPixels) {
-        throw new ResourceLimitError(
-            `Normalized canvas pixel count (${pixelCount}) exceeds the maximum allowed ${opts.maxPixels} pixels. ` +
-                'Set opts.maxPixels to increase the limit.',
-        );
-    }
-
     const diff = opts.shouldCreateDiffFile ? new PNG({ width: images.width, height: images.height }) : undefined;
     const mismatchedPixels = pixelmatch(
         images.first.data,

--- a/src/ports/fsAsyncDiffWriter.ts
+++ b/src/ports/fsAsyncDiffWriter.ts
@@ -6,11 +6,16 @@ import type { AsyncDiffWriterPort } from './asyncTypes';
 
 const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
+// SECU-12: explicit owner-only mode bypasses the process umask so newly created
+// diff files are never world- or group-readable on a default Linux host
+// (default umask 0o022 would otherwise yield 0o644).
+const DIFF_FILE_MODE = 0o600;
+
 export const fsAsyncDiffWriter: AsyncDiffWriterPort = {
     async write(path, data) {
         await mkdir(parse(path).dir, { recursive: true });
         try {
-            const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS);
+            const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS, DIFF_FILE_MODE);
             try {
                 await handle.writeFile(data);
             } finally {

--- a/src/ports/fsAsyncDiffWriter.ts
+++ b/src/ports/fsAsyncDiffWriter.ts
@@ -6,9 +6,15 @@ import type { AsyncDiffWriterPort } from './asyncTypes';
 
 const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
-// SECU-12: explicit owner-only mode bypasses the process umask so newly created
-// diff files are never world- or group-readable on a default Linux host
-// (default umask 0o022 would otherwise yield 0o644).
+// SECU-12: lock diff files to owner-only access (no group, no world).
+// Passing `0o600` as the third arg to `open` covers the creation case
+// — though POSIX still masks it with `~umask`, so umask can only make
+// permissions *more* restrictive, never wider than `0o600`.
+// Calling `handle.chmod` on the open handle afterwards covers the
+// **overwrite** case: when the target already exists, `O_TRUNC` truncates
+// the bytes but does not change the inode's mode, so a pre-existing
+// `0o644` file would otherwise remain group/world-readable. chmod forces
+// the final mode in both cases.
 const DIFF_FILE_MODE = 0o600;
 
 export const fsAsyncDiffWriter: AsyncDiffWriterPort = {
@@ -17,6 +23,7 @@ export const fsAsyncDiffWriter: AsyncDiffWriterPort = {
         try {
             const handle = await open(path, SYMLINK_REFUSING_WRITE_FLAGS, DIFF_FILE_MODE);
             try {
+                await handle.chmod(DIFF_FILE_MODE);
                 await handle.writeFile(data);
             } finally {
                 await handle.close();

--- a/src/ports/fsDiffWriter.ts
+++ b/src/ports/fsDiffWriter.ts
@@ -5,12 +5,17 @@ import type { DiffWriterPort } from './types';
 
 const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
+// SECU-12: explicit owner-only mode bypasses the process umask so newly created
+// diff files are never world- or group-readable on a default Linux host
+// (default umask 0o022 would otherwise yield 0o644).
+const DIFF_FILE_MODE = 0o600;
+
 export const fsDiffWriter: DiffWriterPort = {
     write(path, data) {
         mkdirSync(parse(path).dir, { recursive: true });
         let fd: number;
         try {
-            fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS);
+            fd = openSync(path, SYMLINK_REFUSING_WRITE_FLAGS, DIFF_FILE_MODE);
         } catch (error) {
             if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
                 throw new PathValidationError('Diff write refused: target path is a symlink (TOCTOU defence)');

--- a/src/ports/fsDiffWriter.ts
+++ b/src/ports/fsDiffWriter.ts
@@ -1,13 +1,19 @@
-import { closeSync, constants as fsConstants, mkdirSync, openSync, writeFileSync } from 'node:fs';
+import { closeSync, constants as fsConstants, fchmodSync, mkdirSync, openSync, writeFileSync } from 'node:fs';
 import { parse } from 'node:path';
 import { PathValidationError } from '../errors';
 import type { DiffWriterPort } from './types';
 
 const SYMLINK_REFUSING_WRITE_FLAGS = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
 
-// SECU-12: explicit owner-only mode bypasses the process umask so newly created
-// diff files are never world- or group-readable on a default Linux host
-// (default umask 0o022 would otherwise yield 0o644).
+// SECU-12: lock diff files to owner-only access (no group, no world).
+// Passing `0o600` as the third arg to `openSync` covers the creation case
+// — though POSIX still masks it with `~umask`, so umask can only make
+// permissions *more* restrictive, never wider than `0o600`.
+// Calling `fchmodSync` on the open fd afterwards covers the **overwrite**
+// case: when the target already exists, `O_TRUNC` truncates the bytes but
+// does not change the inode's mode, so a pre-existing `0o644` file would
+// otherwise remain group/world-readable. fchmod forces the final mode in
+// both cases.
 const DIFF_FILE_MODE = 0o600;
 
 export const fsDiffWriter: DiffWriterPort = {
@@ -23,6 +29,7 @@ export const fsDiffWriter: DiffWriterPort = {
             throw error;
         }
         try {
+            fchmodSync(fd, DIFF_FILE_MODE);
             writeFileSync(fd, data);
         } finally {
             closeSync(fd);

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -60,6 +60,13 @@ export type ComparePngOptions = {
      * Regular files at the target path continue to be overwritten as before — only
      * the symlink-redirect attack is closed.
      *
+     * **File mode contract (SECU-12):**
+     * The diff is created with mode `0o600` (owner read/write only). This intentionally
+     * bypasses the process umask so newly written diff files are never group- or
+     * world-readable on a default Linux host (where `umask 0022` would otherwise
+     * yield `0o644`). Callers who need a different file mode can inject a custom
+     * `DiffWriterPort` via `comparePngWithPorts`.
+     *
      * **Residual scope:** the parent-directory race (a symlink planted in a parent
      * component between validation and `mkdirSync(..., { recursive: true })`) is not
      * yet closed; tracked as `SECU-09` in `BACKLOG.md`.

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -61,11 +61,14 @@ export type ComparePngOptions = {
      * the symlink-redirect attack is closed.
      *
      * **File mode contract (SECU-12):**
-     * The diff is created with mode `0o600` (owner read/write only). This intentionally
-     * bypasses the process umask so newly written diff files are never group- or
-     * world-readable on a default Linux host (where `umask 0022` would otherwise
-     * yield `0o644`). Callers who need a different file mode can inject a custom
-     * `DiffWriterPort` via `comparePngWithPorts`.
+     * After the file is opened the writer issues an explicit `fchmod` to mode
+     * `0o600` (owner read/write only), so the final mode is `0o600` regardless
+     * of (a) the process umask and (b) any pre-existing mode at the target
+     * when the diff overwrites an older file. POSIX would otherwise mask the
+     * requested create-mode with `~umask` (so umask can only make permissions
+     * *more* restrictive), and `O_TRUNC` would otherwise leave a pre-existing
+     * `0o644` file at its existing wider mode. Callers who need a different
+     * file mode can inject a custom `DiffWriterPort` via `comparePngWithPorts`.
      *
      * **Residual scope:** the parent-directory race (a symlink planted in a parent
      * component between validation and `mkdirSync(..., { recursive: true })`) is not

--- a/src/validatePath.ts
+++ b/src/validatePath.ts
@@ -46,6 +46,39 @@ function realpathExistingPath(targetPath: string): string {
 }
 
 /**
+ * Asserts that an output-mode target is not an existing symlink or directory.
+ *
+ * SECU-11: This shape check intentionally runs *after* the `baseDir` containment
+ * check so its specific error messages ("must not be an existing symlink",
+ * "must not be an existing directory") cannot be used as a filesystem-probing
+ * oracle for paths outside the security boundary. When `baseDir` is not set
+ * there is no boundary to enforce — callers can write anywhere — so the legacy
+ * "shape-check first" behaviour is preserved (no oracle exists either way).
+ *
+ * Mirrors the VUL-05 / `getPngData.ts:95-97` pattern of unifying error responses
+ * across security boundaries to prevent enumeration.
+ */
+function assertOutputTargetShape(resolved: string): void {
+    try {
+        const fileStats = lstatSync(resolved);
+        if (fileStats.isSymbolicLink()) {
+            throw new PathValidationError('Invalid file path: output path must not be an existing symlink');
+        }
+        if (statSync(resolved).isDirectory()) {
+            throw new PathValidationError('Invalid file path: output path must not be an existing directory');
+        }
+    } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (!(error instanceof PathValidationError) && code !== 'ENOENT' && code !== 'ENOTDIR') {
+            throw error;
+        }
+        if (error instanceof PathValidationError) {
+            throw error;
+        }
+    }
+}
+
+/**
  * Validates and resolves a file path string with optional directory containment checks.
  *
  * **Basic validation (always applied):**
@@ -65,6 +98,12 @@ function realpathExistingPath(targetPath: string): string {
  * - For output paths: resolves the parent directory then re-attaches the filename
  *   (allows writing new files in a writable directory even if the file doesn't exist yet)
  *
+ * **Check ordering (SECU-11):**
+ * - When `baseDir` is provided, the containment check runs *before* the output-mode
+ *   symlink/directory shape check, so out-of-bounds paths always surface as
+ *   `Path traversal detected: …` and never as `must not be an existing symlink/directory`.
+ *   This closes a filesystem-enumeration oracle for paths outside the boundary.
+ *
  * @param filePath - The file path string to validate
  * @param baseDir  - Optional directory; when set, the resolved path must reside within it
  * @param mode     - 'input' (enforce symlink containment) or 'output' (reject existing symlinks)
@@ -83,25 +122,7 @@ export function validatePath(filePath: string, baseDir?: string, mode: ValidateP
     }
 
     const resolved = resolve(filePath);
-    if (mode === 'output') {
-        try {
-            const fileStats = lstatSync(resolved);
-            if (fileStats.isSymbolicLink()) {
-                throw new PathValidationError('Invalid file path: output path must not be an existing symlink');
-            }
-            if (statSync(resolved).isDirectory()) {
-                throw new PathValidationError('Invalid file path: output path must not be an existing directory');
-            }
-        } catch (error) {
-            const code = (error as NodeJS.ErrnoException).code;
-            if (!(error instanceof PathValidationError) && code !== 'ENOENT' && code !== 'ENOTDIR') {
-                throw error;
-            }
-            if (error instanceof PathValidationError) {
-                throw error;
-            }
-        }
-    }
+
     if (baseDir !== undefined) {
         const normalizedBaseDir = resolve(baseDir);
         if (!isContained(normalizedBaseDir, resolved)) {
@@ -117,6 +138,15 @@ export function validatePath(filePath: string, baseDir?: string, mode: ValidateP
         if (!isContained(realBaseDir, realTargetPath)) {
             throw new PathValidationError(`Path traversal detected: "${resolved}" is outside the allowed directory "${realBaseDir}"`);
         }
+
+        if (mode === 'output') {
+            assertOutputTargetShape(resolved);
+        }
+        return resolved as ValidatedPath;
+    }
+
+    if (mode === 'output') {
+        assertOutputTargetShape(resolved);
     }
 
     return resolved as ValidatedPath;


### PR DESCRIPTION
## Summary

Closes three security findings filed during the 2026-05-16 CTF audit (see `BACKLOG.md`).

- **SECU-10 (P1)** — `maxPixels` guard on the normalized canvas now fires in `normalizeImages` *before* `extendImage` allocates oversized RGBA buffers. Previously a `(16384×1024, 1024×16384)` input pair (each within `DEFAULT_MAX_PIXELS`) forced ~2 GiB of zero-filled allocation before the downstream guard in `runComparison` could throw.
- **SECU-11 (P2)** — `validatePath` output-mode `lstatSync`/`statSync` shape checks are now extracted into `assertOutputTargetShape` and invoked **after** the `baseDir` containment check. Closes a three-way filesystem-enumeration oracle (exists-symlink / exists-directory / anything-else) for arbitrary absolute paths.
- **SECU-12 (P2)** — both diff writers (`fsDiffWriter`, `fsAsyncDiffWriter`) now pass an explicit `0o600` mode to `openSync` / `open`. Previously diff files inherited `0o666 & ~umask` (typically `0o644` — **world-readable** on a default Linux host), leaking sensitive screenshot diffs to every local uid on shared CI runners.

## Why bundle three fixes?

All three landed in the same CTF iteration and share the security-boundary theme. Each fix is self-contained and could in principle ship separately, but the changes touch disjoint files (`pipeline/`, `validatePath.ts`, `ports/`), so review surface is small. The commit message details each finding individually for git-blame friendliness.

## Behavioural contract changes

- The DoS-payload `(16384×1024, 1024×16384)` pair still throws `ResourceLimitError` with **the same** `Normalized canvas pixel count (…) exceeds the maximum allowed … pixels` message. Only the call-stack origin changes (now `normalizeImages` instead of `runComparison`).
- Out-of-bounds paths still throw `PathValidationError`. Outside `baseDir`, the message is now uniformly `Path traversal detected: …` instead of sometimes `output path must not be an existing symlink/directory`. Inside `baseDir`, the legacy shape-check messages are preserved.
- Diff files are created at mode `0o600` instead of `0o666 & ~umask`. Callers needing a different mode can inject a custom `DiffWriterPort` via `comparePngWithPorts`. TSDoc on `diffFilePath` documents this.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:license` — clean
- [x] `npm run codemap:check` — clean (CODEMAP.md regenerated)
- [x] `npm run test:unit` — **383 / 383 pass; 100% coverage on statements, branches, functions, lines**
- [x] `npm run test:e2e` — 47 / 47 pass
- [x] `npm run build` — clean

New tests:
- `__tests__/pipeline/normalizeImages.test.ts` — proves the SECU-10 throw originates from `normalizeImages` itself (impossible pre-fix because the guard lived downstream) for both the size-difference path and a constructed same-size `LoadedSources`.
- `__tests__/validatePath.symlinks.test.ts` (new `describe` block, 6 tests) — proves out-of-bounds symlinks/directories/regular-files all surface as `Path traversal detected: …` and never as shape-check phrases. Includes regression guards for in-bounds shape-check behaviour and for the legacy `baseDir === undefined` path.
- `__tests__/ports/fs{,Async}DiffWriter.symlink.test.ts` — proves diff files are created at mode `0o600` even under a deliberately permissive `umask 0o000`.

## Files touched

- `src/pipeline/normalizeImages.ts` — SECU-10 guard relocation
- `src/pipeline/runComparison.ts` — SECU-10 redundant guard removed
- `src/validatePath.ts` — SECU-11 reorder + `assertOutputTargetShape` extraction
- `src/ports/fsDiffWriter.ts` — SECU-12 explicit `0o600` mode
- `src/ports/fsAsyncDiffWriter.ts` — SECU-12 explicit `0o600` mode
- `src/types/compare.options.ts` — SECU-12 TSDoc contract on `diffFilePath`
- `docs/ARCHITECTURE.md` — reflects new invariants for all three findings
- `BACKLOG.md` — three new items (filed during CTF iterations) flipped to `Status: Done`
- `CODEMAP.md` — regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)