### PR TITLE
Fix excludedAreas overlapping the size-extension region being reported as mismatches

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.1.1"
     },
-    "sourceHash": "95b1e226e650b25b2a6cccd76b99a958bfcfc63545c62512cf6b9290e93c93a2",
+    "sourceHash": "426a8af16b1e8a83555113cf0bcab6f118a285b753cf8f993a2102ca020c4786",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",

--- a/__tests__/comparePng.logic.test.ts
+++ b/__tests__/comparePng.logic.test.ts
@@ -36,6 +36,25 @@ test('throws when both inputs are invalid', () => {
     ).toThrow(InvalidInputError);
 });
 
+test('size-difference band is reported as a mismatch when not excluded (control)', () => {
+    // 4x4 vs 4x2: the bottom two rows exist only in the first image and become
+    // extended (green) padding in the second, so they differ.
+    const result = comparePng(createPngBuffer(4, 4, [255, 0, 0, 255]), createPngBuffer(4, 2, [255, 0, 0, 255]), {});
+
+    expect(result).toBe(8);
+});
+
+test('excludedAreas overlapping the size-extension region always match (contract)', () => {
+    // Excluding the exact bottom band that only exists in the larger image must
+    // make it match — excluded areas "always match regardless of content", even
+    // when they overlap regions added by size extension.
+    const result = comparePng(createPngBuffer(4, 4, [255, 0, 0, 255]), createPngBuffer(4, 2, [255, 0, 0, 255]), {
+        excludedAreas: [{ x1: 0, y1: 2, x2: 3, y2: 3 }],
+    });
+
+    expect(result).toBe(0);
+});
+
 test('excludedAreas validation runs before image mutation', () => {
     const diffDir = resolve('./test-results/logic-invalid-area');
     const diffFilePath = resolve(diffDir, 'diff.png');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,10 +117,10 @@ Responsibilities:
 - converts `LoadedPng` into comparable `PNGWithMetadata`
 - clones valid decoded PNGs before mutation
 - turns one-sided invalid inputs into comparable `0×0` canvases
-- paints `excludedAreas` on both images
 - enforces `maxPixels` on the normalized comparison canvas (SECU-10), **before** any extension allocates oversized buffers
 - extends both images to `max(width) × max(height)`
 - paints padded regions with `extendedAreaColor`
+- paints `excludedAreas` on both images **last**, on the final canvas, so they always match regardless of content — including regions added by size extension
 
 Important invariant: normalization returns **new images** and does not mutate decoded source PNGs in place.
 

--- a/src/pipeline/normalizeImages.ts
+++ b/src/pipeline/normalizeImages.ts
@@ -25,11 +25,6 @@ export function normalizeImages(sources: LoadedSources, opts: ResolvedOptions): 
     let first = toComparablePng(sources.first);
     let second = toComparablePng(sources.second);
 
-    if (opts.excludedAreas.length > 0) {
-        addColoredAreasToImage(first, opts.excludedAreas, opts.excludedAreaColor);
-        addColoredAreasToImage(second, opts.excludedAreas, opts.excludedAreaColor);
-    }
-
     const { width: width1, height: height1 } = first;
     const { width: width2, height: height2 } = second;
     const width = Math.max(width1, width2);
@@ -53,6 +48,15 @@ export function normalizeImages(sources: LoadedSources, opts: ResolvedOptions): 
 
         fillImageSizeDifference(first, width1, height1, opts.extendedAreaColor);
         fillImageSizeDifference(second, width2, height2, opts.extendedAreaColor);
+    }
+
+    // Paint excluded areas last, on the final normalized canvas, so they always match
+    // regardless of content — including regions added by size extension. Painting before
+    // extension left an excluded band clamped out of the smaller image, which the
+    // size-difference fill then coloured differently from the larger image.
+    if (opts.excludedAreas.length > 0) {
+        addColoredAreasToImage(first, opts.excludedAreas, opts.excludedAreaColor);
+        addColoredAreasToImage(second, opts.excludedAreas, opts.excludedAreaColor);
     }
 
     return { first, second, width, height };


### PR DESCRIPTION
## Summary

- Fixed excluded areas that overlap a size-difference (extension) region being reported as mismatched pixels, in violation of the documented contract that excluded areas "always match regardless of content" (`README.md:229`, `src/types/compare.options.ts:46`).
- Added regression coverage for the size-extension/exclusion overlap, plus a control case proving the non-excluded band still mismatches.

## Root Cause

`src/pipeline/normalizeImages.ts` painted `excludedAreas` **before** extending the canvas:

1. `addColoredAreasToImage` painted the excluded rectangle (blue) on the *original-sized* images. `addColoredAreasToImage` clamps coordinates to `[0, width-1] × [0, height-1]`, so a band that lies outside the smaller image was clamped away and never painted there.
2. `extendImage` grew the smaller image to `max(width) × max(height)`.
3. `fillImageSizeDifference` then painted that same band with `extendedAreaColor` (green) in the smaller image.

Result: in the larger image the band was blue (excluded), in the smaller image it was green (padding) → `pixelmatch` counted every pixel in the band as a mismatch. The user explicitly excluded that region, yet it was still reported as different.

## Fix

Move the `addColoredAreasToImage` block in `normalizeImages` to run **last**, after `extendImage` + `fillImageSizeDifference`, so the excluded rectangle is painted identically on the final normalized canvas of both images. The dimension reads (`width1/height1/width2/height2`) and the SECU-10 `maxPixels` guard are unaffected — painting never changes image dimensions — and same-size inputs (which skip the extension branch entirely) behave identically to before. This is the minimal change that restores the documented contract.

`docs/ARCHITECTURE.md` and `CODEMAP.md` are updated to reflect the new ordering.

## Tests

- `npx vitest run __tests__/comparePng.logic.test.ts __tests__/pipeline/normalizeImages.test.ts` → 8 passed
- Verified the new contract test **fails before** the fix (`expected 0, got 8`) and **passes after**.
- `npm run test:unit` (clean → codemap:check → lint → format:check → license → typecheck → repo-wide coverage) → **394 passed**, coverage **100%** lines/branches/functions/statements.

## Risk

Low. Single-function reordering with no API change. Behavior changes only for the previously-broken case (excluded area overlapping a size-extension region), which now matches the documented contract. Same-size comparisons and the existing `normalizeImages` snapshot/pixel assertions are unchanged.