### PR TITLE
chore: release 6.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
             - run: npm ci
+            - run: npx playwright install --with-deps chromium
             - run: npm audit --audit-level=high
             - run: npm run build
             - run: npm publish --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-06-03
+
+### Security
+
+- **SECU-10** — Moved the normalized-canvas `maxPixels` guard into
+  `normalizeImages`, _before_ `extendImage` runs. The check previously lived in
+  `runComparison`, which fires only after two extended canvases are already
+  allocated, so a `(16384x1024, 1024x16384)` input pair — each within
+  `DEFAULT_MAX_PIXELS` — could force ~2 GiB of zero-filled RGBA allocation
+  before the guard could throw.
+- **SECU-11** — `validatePath` now performs the `baseDir` containment check
+  _before_ the symlink/directory shape checks, closing an oracle that leaked
+  exists-symlink / exists-directory / other status for arbitrary absolute paths
+  when a security boundary was configured. Every out-of-bounds path now yields a
+  uniform `Path traversal detected: ...` error.
+- **SECU-12** — Both diff writers now issue an explicit `fchmodSync(fd, 0o600)`
+  / `await handle.chmod(0o600)` after open. `open(path, flags, 0o600)` only sets
+  the mode on newly created files (and is narrowed by umask), so overwriting a
+  pre-existing `0o644` diff left it group/world-readable; the post-open chmod
+  forces `0o600` in both the create and overwrite cases.
+- Hardened the sync diff writer against partial writes by replacing `writeSync`
+  (which can write fewer bytes than requested) with `writeFileSync`, which loops
+  until the full buffer is flushed. The async path already guaranteed
+  full-buffer writes via `FileHandle.writeFile`.
+
 ### Added
 
 - **RELI-10** — New public `ComparisonError` (`code: 'ERR_COMPARISON'`) thrown
@@ -17,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comparison-kernel failure signals an integrity bug, not a recoverable input
   problem. Applies to both `comparePng` and `comparePngAsync` since they share
   `runComparison`.
+
+### Fixed
+
+- `excludedAreas` are now painted on the final normalized canvas, _after_ size
+  extension, so an excluded band that falls outside the smaller image is no
+  longer clamped away and reported as a mismatch. Same-size inputs are
+  unaffected.
+- The `./vitest` subpath export no longer ships an empty CommonJS
+  `vitest.types.js`; the `declare module 'vitest'` augmentation is inlined into
+  `vitest.mts`, and the published types entry points to the co-located `.d.mts`.
 
 ## [6.1.1] - 2026-05-16
 

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -12,7 +12,7 @@ Schema: `codemap.v2`
     "schema": "codemap.v2",
     "repo": {
         "name": "png-visual-compare",
-        "version": "6.1.1"
+        "version": "6.2.0"
     },
     "sourceHash": "426a8af16b1e8a83555113cf0bcab6f118a285b753cf8f993a2102ca020c4786",
     "entrypoints": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "png-visual-compare",
-    "version": "6.1.1",
+    "version": "6.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "png-visual-compare",
-            "version": "6.1.1",
+            "version": "6.2.0",
             "license": "MIT",
             "os": [
                 "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "png-visual-compare",
-    "version": "6.1.1",
+    "version": "6.2.0",
     "description": "Node.js utility to compare PNG files or their areas",
     "keywords": [
         "visual testing",


### PR DESCRIPTION
## Release `png-visual-compare@6.2.0`

Cuts the first release since 6.1.0. npm is at **6.1.0**; `main` carries the never-published 6.1.1 (SECU-03) **plus** a new public `ComparisonError` export (RELI-10), three more security fixes, and bug fixes. A new public API ⇒ **minor** bump, so consumers go **6.1.0 → 6.2.0** directly.

### What's in this PR
- **Version** → `6.2.0` in `package.json` + `package-lock.json`; `CODEMAP.md` version stamp regenerated (`npm run codemap`) so `codemap:check` stays green.
- **CHANGELOG** — full audit of `6.1.0..HEAD` under `[6.2.0]`:
  - **Security:** SECU-10 (maxPixels guard before canvas extension), SECU-11 (containment-before-shape oracle), SECU-12 (explicit `fchmod 0o600` on overwrite), sync diff-writer partial-write guard.
  - **Added:** `ComparisonError` public export (RELI-10).
  - **Fixed:** `excludedAreas` paint order after size extension (#93); inlined vitest module augmentation.
  - `[6.1.1]`/SECU-03 retained as historical.
- **publish.yml** — adds `npx playwright install --with-deps chromium`. `npm publish` triggers `prepublishOnly` → full e2e, which needs a browser; Ubuntu requires `--with-deps` (as `test.yml` already does). Without this, the first automated publish would fail.

### Verification (local)
- `npm run test:unit` ✅ — 394 tests, **100%** coverage (lines/branches/funcs/stmts)
- `npm run build` ✅ — emits `out/{index,jest}.js`, `out/vitest.mjs`, `out/index.d.ts`
- `npm run format:check` ✅ · `npm audit --audit-level=high` ✅ (0 vulns)
- `npm pack --dry-run` ✅ — no stray files (only `./out` ships at publish time)

### Release path (after merge — done by maintainer)
1. Merge this PR.
2. `gh release create release/v6.2.0 --title v6.2.0 --latest --notes "<6.2.0 CHANGELOG section>"` — **not** `--prerelease` (`publish.yml` skips prereleases).
3. `publish.yml` runs `npm publish --provenance`; verify `npm view png-visual-compare version` = `6.2.0` + provenance badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)