### PR TITLE
fix: remediate bugfix-pr audit candidates (RELI-06/07, checkerboard, builder clamp)

### DIFF
--- a/BACKLOG-ARCHIVE.md
+++ b/BACKLOG-ARCHIVE.md
@@ -54,6 +54,12 @@
 - [x] 🟢 🐛 RELI [RELI-10]: Wrap `pixelmatch` errors → `ComparisonError`
     - **Impl:** New public `ComparisonError extends Error` (`code: 'ERR_COMPARISON'`) in `src/errors.ts`; `runComparison` wraps the `pixelmatch(...)` call in try/catch and rethrows with the original on the ES2022 `cause` property; exported from `src/index.ts`; README + ARCHITECTURE error-model sections updated; unit tests cover Error / non-Error throws plus a passthrough.
     - **Rat:** Raw `pixelmatch` throws leaked through both sync and async public APIs as untyped `Error`s — callers had to parse free-form messages to branch on comparison-kernel failures, defeating the structured-error model established by RELI-03.
+- [x] 🟢 🐛 RELI [RELI-06]: Reject negative coords in `validateArea`
+    - **Impl:** `validateArea` now throws `InvalidInputError` (`excludedAreas[i]: coordinates must be non-negative`) when any of `x1/y1/x2/y2` is `< 0`, after the finite-integer check and before the ordering checks; sync + async exception suites gain negative-coordinate cases.
+    - **Rat:** Negative excluded-area coordinates were silently clamped to `0` inside `addColoredAreasToImage`, so a caller typo (e.g. `x1: -5`) painted a different region than requested with no signal — fail-fast at the validation boundary instead. The paint layer keeps its defensive clamp for direct callers.
+- [x] 🟢 🐛 RELI [RELI-07]: `persistDiff` use `=== 0` not `<= 0`
+    - **Impl:** `getPersistableDiff` guard changed from `result.mismatchedPixels <= 0` to `=== 0`.
+    - **Rat:** `pixelmatch` returns a non-negative mismatch count, so `<= 0` and `=== 0` are behaviourally identical; `=== 0` states the actual contract ("no mismatches ⇒ no diff file") without implying negative counts are reachable.
 - [x] 🔴 ♻️ TYPE [TYPE-01]: Replace `PngData` sentinel with discriminated union
     - **Impl:** Replaced `PngData` with `LoadedPng = {kind:'valid',png} | {kind:'invalid',reason}`; updated `getPngData` + loaders + tests; removed from public barrel (semver-major).
     - **Rat:** Sentinel encoded failure as a fake `0×0` PNG — weakened invariants and let invalid input flow through as if real.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -45,8 +45,6 @@
 - [ ] 🟢 ♻️ TYPE [TYPE-08]: Rename `isComparePngOptions` → `isPlainObject`
 - [ ] 🟢 ♻️ TYPE [TYPE-09]: `Partial<ComparisonPorts>` on overload
 - [ ] 🟢 🐛 RELI [RELI-05]: `Promise.allSettled` in `comparePngAsync`
-- [ ] 🟢 🐛 RELI [RELI-06]: Reject negative coords in `validateArea`
-- [ ] 🟢 🐛 RELI [RELI-07]: `persistDiff` use `=== 0` not `<= 0`
 - [ ] 🟢 🐛 RELI [RELI-08]: Validate-before-bind in `resolveOptions`
 - [ ] 🟢 🐛 RELI [RELI-09]: Wrap `realpathNative` errors in `PathValidationError`
 - [ ] 🟢 📦 API [API-03]: In-memory diff buffer (no disk round-trip)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **checkerboard** — `pixelmatchOptions.checkerboard` is now forwarded to
+  pixelmatch (7.2.0+), letting callers control whether semi-transparent pixels
+  are blended against a checkerboard pattern (`true`, the default) or plain
+  white (`false`). Validated as a boolean by `validatePixelmatchOptions`.
+
+### Changed
+
+- **RELI-06** — `validateArea` now rejects negative `excludedAreas`
+  coordinates with `InvalidInputError` (`coordinates must be non-negative`)
+  instead of letting `addColoredAreasToImage` silently clamp them to `0`. A
+  negative coordinate is almost always a caller typo, so it now fails fast at
+  the validation boundary. Potentially breaking for callers that relied on the
+  previous clamping behaviour.
+
+### Fixed
+
+- **RELI-07** — the `persistDiff` guard now reads `mismatchedPixels === 0`
+  rather than `<= 0`. Behaviourally identical (pixelmatch never returns a
+  negative count) but states the actual "no mismatches ⇒ no diff file"
+  contract.
+- **excluded-areas-builder** — the drawing tool now clamps coordinates to the
+  last valid pixel index (`naturalW - 1` / `naturalH - 1`), so emitted areas
+  are valid inclusive pixel indices instead of one-past-the-edge values.
+
 ## [6.2.0] - 2026-06-03
 
 ### Security

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.2.0"
     },
-    "sourceHash": "426a8af16b1e8a83555113cf0bcab6f118a285b753cf8f993a2102ca020c4786",
+    "sourceHash": "86d91808ca03900278cedc6227b4a3b0582fa8ffe12a822578d57dd89e9ebf43",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -46,7 +46,7 @@ Schema: `codemap.v2`
             "kind": "type",
             "entrypoint": "src/index.ts",
             "file": "src/types/compare.options.ts",
-            "line": 43,
+            "line": 49,
             "signature": "export type ComparePngOptions = { excludedAreas?: Area[]; diffFilePath?: string; throwErrorOnInvalidInputData?: boolean; extendedAreaColor?: Color; excludedAreaColor?: Color; maxDimension?: number; ma…",
             "jsdoc": null,
             "typeOnly": true
@@ -1524,7 +1524,7 @@ Schema: `codemap.v2`
                 {
                     "name": "ComparePngOptions",
                     "kind": "type",
-                    "line": 43,
+                    "line": 49,
                     "exported": true,
                     "signature": "export type ComparePngOptions = { excludedAreas?: Area[]; diffFilePath?: string; throwErrorOnInvalidInputData?: boolean; extendedAreaColor?: Color; excludedAreaColor?: Color; maxDimension?: number; ma…",
                     "members": null,

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ import type { LoadedPng } from 'png-visual-compare';
 
 The library now fails fast for malformed option data instead of relying on downstream behavior:
 
-- `excludedAreas` must be an array of finite integer rectangles with `x1 <= x2` and `y1 <= y2`
+- `excludedAreas` must be an array of non-negative finite integer rectangles with `x1 <= x2` and `y1 <= y2`
 - `pixelmatchOptions` must be an object with validated numeric/boolean/tuple fields
 - `diffFilePath`, `inputBaseDir`, and `diffOutputBaseDir` must be strings when provided
 - `diffFilePath` now rejects existing directories and existing symlinks in output mode
@@ -266,15 +266,16 @@ type Color = {
 
 ### `PixelmatchOptions`
 
-| Option         | Type        | Default         | Description                                                 |
-| -------------- | ----------- | --------------- | ----------------------------------------------------------- |
-| `threshold`    | `number`    | `0.1`           | Matching threshold `0`–`1`. Lower = more sensitive          |
-| `includeAA`    | `boolean`   | `false`         | When `true`, anti-aliased pixels count as mismatches        |
-| `alpha`        | `number`    | `0.1`           | Opacity of unchanged pixels in the diff image               |
-| `aaColor`      | `[r, g, b]` | `[255, 255, 0]` | Colour of anti-aliased pixels in the diff                   |
-| `diffColor`    | `[r, g, b]` | `[255, 0, 0]`   | Colour of differing pixels in the diff                      |
-| `diffColorAlt` | `[r, g, b]` | `undefined`     | Alternative diff colour for dark pixels (dark-mode support) |
-| `diffMask`     | `boolean`   | `false`         | Show only changed pixels on a transparent background        |
+| Option         | Type        | Default         | Description                                                     |
+| -------------- | ----------- | --------------- | --------------------------------------------------------------- |
+| `threshold`    | `number`    | `0.1`           | Matching threshold `0`–`1`. Lower = more sensitive              |
+| `includeAA`    | `boolean`   | `false`         | When `true`, anti-aliased pixels count as mismatches            |
+| `alpha`        | `number`    | `0.1`           | Opacity of unchanged pixels in the diff image                   |
+| `aaColor`      | `[r, g, b]` | `[255, 255, 0]` | Colour of anti-aliased pixels in the diff                       |
+| `diffColor`    | `[r, g, b]` | `[255, 0, 0]`   | Colour of differing pixels in the diff                          |
+| `diffColorAlt` | `[r, g, b]` | `undefined`     | Alternative diff colour for dark pixels (dark-mode support)     |
+| `diffMask`     | `boolean`   | `false`         | Show only changed pixels on a transparent background            |
+| `checkerboard` | `boolean`   | `true`          | Blend semi-transparent pixels against a checkerboard (vs white) |
 
 ### Errors
 

--- a/__tests__/adapters/toPixelmatchOptions.test.ts
+++ b/__tests__/adapters/toPixelmatchOptions.test.ts
@@ -12,6 +12,7 @@ describe('toPixelmatchOptions', () => {
                 diffColor: [4, 5, 6],
                 diffColorAlt: [7, 8, 9],
                 diffMask: true,
+                checkerboard: false,
             }),
         ).toEqual({
             threshold: 0.2,
@@ -21,6 +22,7 @@ describe('toPixelmatchOptions', () => {
             diffColor: [4, 5, 6],
             diffColorAlt: [7, 8, 9],
             diffMask: true,
+            checkerboard: false,
         });
     });
 

--- a/__tests__/comparePng.exceptions.test.ts
+++ b/__tests__/comparePng.exceptions.test.ts
@@ -352,6 +352,22 @@ const testDataArrayOptionValidation: {
         errorPattern: 'maxPixels must be a positive integer or Infinity',
         errorClass: TypeError,
     },
+    {
+        id: 28,
+        name: 'excludedAreas negative x1 coordinate is rejected',
+        opts: { excludedAreas: [{ x1: -1, y1: 0, x2: 10, y2: 10 }] },
+        throws: true,
+        errorPattern: 'excludedAreas[0]: coordinates must be non-negative',
+        errorClass: InvalidInputError,
+    },
+    {
+        id: 29,
+        name: 'excludedAreas fully negative rectangle is rejected',
+        opts: { excludedAreas: [{ x1: -10, y1: -10, x2: -1, y2: -1 }] },
+        throws: true,
+        errorPattern: 'excludedAreas[0]: coordinates must be non-negative',
+        errorClass: InvalidInputError,
+    },
 ];
 
 for (const testData of testDataArrayOptionValidation) {

--- a/__tests__/comparePng.pixelmatch-options.test.ts
+++ b/__tests__/comparePng.pixelmatch-options.test.ts
@@ -150,6 +150,20 @@ const testDataArrayPixelmatchValidation: {
         pixelmatchOptions: { diffColorAlt: [12, 34, 56] },
         throws: false,
     },
+    {
+        id: 15,
+        name: 'checkerboard non-boolean is rejected',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pixelmatchOptions: { checkerboard: 'yes' as any },
+        throws: true,
+        message: 'pixelmatchOptions.checkerboard must be a boolean',
+    },
+    {
+        id: 16,
+        name: 'checkerboard boolean is accepted',
+        pixelmatchOptions: { checkerboard: false },
+        throws: false,
+    },
 ];
 
 for (const testData of testDataArrayPixelmatchValidation) {

--- a/__tests__/comparePngAsync.exceptions.test.ts
+++ b/__tests__/comparePngAsync.exceptions.test.ts
@@ -355,6 +355,22 @@ const testDataArrayOptionValidation: {
         errorPattern: 'maxPixels must be a positive integer or Infinity',
         errorClass: TypeError,
     },
+    {
+        id: 28,
+        name: 'excludedAreas negative x1 coordinate is rejected',
+        opts: { excludedAreas: [{ x1: -1, y1: 0, x2: 10, y2: 10 }] },
+        throws: true,
+        errorPattern: 'excludedAreas[0]: coordinates must be non-negative',
+        errorClass: InvalidInputError,
+    },
+    {
+        id: 29,
+        name: 'excludedAreas fully negative rectangle is rejected',
+        opts: { excludedAreas: [{ x1: -10, y1: -10, x2: -1, y2: -1 }] },
+        throws: true,
+        errorPattern: 'excludedAreas[0]: coordinates must be non-negative',
+        errorClass: InvalidInputError,
+    },
 ];
 
 for (const testData of testDataArrayOptionValidation) {

--- a/src/adapters/toPixelmatchOptions.ts
+++ b/src/adapters/toPixelmatchOptions.ts
@@ -16,5 +16,6 @@ export function toPixelmatchOptions(opts?: PixelmatchOptions): PixelmatchRawOpti
         ...(opts.diffColor !== undefined ? { diffColor: opts.diffColor } : {}),
         ...(opts.diffColorAlt !== undefined ? { diffColorAlt: opts.diffColorAlt } : {}),
         ...(opts.diffMask !== undefined ? { diffMask: opts.diffMask } : {}),
+        ...(opts.checkerboard !== undefined ? { checkerboard: opts.checkerboard } : {}),
     };
 }

--- a/src/pipeline/persistDiff.ts
+++ b/src/pipeline/persistDiff.ts
@@ -9,7 +9,7 @@ export type PersistableDiff = {
 };
 
 export function getPersistableDiff(result: ComparisonResult, opts: ResolvedOptions): PersistableDiff | undefined {
-    if (result.mismatchedPixels <= 0 || !opts.shouldCreateDiffFile || !result.diff || !opts.diffFilePath) {
+    if (result.mismatchedPixels === 0 || !opts.shouldCreateDiffFile || !result.diff || !opts.diffFilePath) {
         return undefined;
     }
 

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -38,6 +38,12 @@ export type PixelmatchOptions = {
      * @default false
      */
     diffMask?: boolean;
+    /**
+     * Whether to blend semi-transparent pixels against a checkerboard pattern (`true`) or plain
+     * white (`false`) when comparing. Affects how partially transparent pixels are matched.
+     * @default true
+     */
+    checkerboard?: boolean;
 };
 
 export type ComparePngOptions = {

--- a/src/validateArea.ts
+++ b/src/validateArea.ts
@@ -14,6 +14,9 @@ export function validateArea(area: Area, index: number): void {
     ) {
         throw new InvalidInputError(`excludedAreas[${index}]: coordinates must be finite integers`);
     }
+    if (![x1, y1, x2, y2].every((coordinate) => coordinate >= 0)) {
+        throw new InvalidInputError(`excludedAreas[${index}]: coordinates must be non-negative`);
+    }
     if (x1 > x2) {
         throw new InvalidInputError(`excludedAreas[${index}]: x1 must be <= x2`);
     }

--- a/src/validatePixelmatchOptions.ts
+++ b/src/validatePixelmatchOptions.ts
@@ -32,6 +32,7 @@ export function validatePixelmatchOptions(opts: PixelmatchOptions): void {
     validateUnitInterval('pixelmatchOptions.alpha', opts.alpha);
     validateBoolean('pixelmatchOptions.includeAA', opts.includeAA);
     validateBoolean('pixelmatchOptions.diffMask', opts.diffMask);
+    validateBoolean('pixelmatchOptions.checkerboard', opts.checkerboard);
 
     if (opts.aaColor !== undefined) validateColorTuple('pixelmatchOptions.aaColor', opts.aaColor);
     if (opts.diffColor !== undefined) validateColorTuple('pixelmatchOptions.diffColor', opts.diffColor);

--- a/tools/excluded-areas-builder.html
+++ b/tools/excluded-areas-builder.html
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; base-uri 'none'; object-src 'none'; script-src 'sha256-KxcnPUdqXBjdkdeKLwhyZay5KzWqMjkj1zh6CBBTHpM='; style-src 'sha256-rxhPnDCcdJeCfOiyZXOP5TSV4njfY4rSCBARxyvfU3Q='; img-src blob:;"
+            content="default-src 'none'; base-uri 'none'; object-src 'none'; script-src 'sha256-EkVEUkycSCesQimD2nlLKZStNKu6Fh81+V0ZbxMp75A='; style-src 'sha256-rxhPnDCcdJeCfOiyZXOP5TSV4njfY4rSCBARxyvfU3Q='; img-src blob:;"
         />
         <title>Excluded Areas Builder</title>
         <style>
@@ -479,7 +479,7 @@
                 }
 
                 const pos = svgCoords(e);
-                drawStart = { x: clamp(pos.x, 0, naturalW), y: clamp(pos.y, 0, naturalH) };
+                drawStart = { x: clamp(pos.x, 0, naturalW - 1), y: clamp(pos.y, 0, naturalH - 1) };
                 isDrawing = true;
                 selectedId = null;
 
@@ -502,8 +502,8 @@
             window.addEventListener('mousemove', (e) => {
                 if (!isDrawing) return;
                 const pos = svgCoords(e);
-                const cx = clamp(pos.x, 0, naturalW);
-                const cy = clamp(pos.y, 0, naturalH);
+                const cx = clamp(pos.x, 0, naturalW - 1);
+                const cy = clamp(pos.y, 0, naturalH - 1);
                 previewRect.setAttribute('x', Math.min(drawStart.x, cx));
                 previewRect.setAttribute('y', Math.min(drawStart.y, cy));
                 previewRect.setAttribute('width', Math.abs(cx - drawStart.x));
@@ -515,8 +515,8 @@
                 isDrawing = false;
 
                 const pos = svgCoords(e);
-                const cx = clamp(pos.x, 0, naturalW);
-                const cy = clamp(pos.y, 0, naturalH);
+                const cx = clamp(pos.x, 0, naturalW - 1);
+                const cy = clamp(pos.y, 0, naturalH - 1);
 
                 if (previewRect) {
                     previewRect.remove();


### PR DESCRIPTION
## Summary

Remediates the four actionable candidates surfaced by the `bugfix-pr` audit. The fifth candidate — the trailing-comma regex in `parseSerializedPngSnapshot` — was **deliberately left as-is**: it is intentional defensive parsing with a committed test (`pngSnapshotMatcher.test.ts:226` proves trailing-comma tolerance), so removing it would delete a tested feature, not fix a bug.

| # | Candidate | Change | Type |
|---|-----------|--------|------|
| RELI-06 | negative excluded-area coords silently clamped | `validateArea` now **rejects** them | 🐛 fix (behaviour change) |
| RELI-07 | `persistDiff` guard `<= 0` | use `=== 0` | 🐛 fix (clarity) |
| — | `checkerboard` pixelmatch option not exposed | forward + validate it | 📦 feat |
| — | builder tool emits one-past-edge coords | clamp to last pixel index | 🐛 fix (dev tool) |

## Details

**RELI-06 — reject negative `excludedAreas` coordinates**
`validateArea` throws `InvalidInputError` (`excludedAreas[i]: coordinates must be non-negative`) when any of `x1/y1/x2/y2` is `< 0`, instead of letting `addColoredAreasToImage` silently clamp them to `0` (a clamp that paints a different region than the caller asked for, with no signal). The paint layer keeps its defensive clamp for direct callers. **Potentially breaking** for callers that relied on the old clamping.

**RELI-07 — `persistDiff` uses `=== 0`**
`pixelmatch` never returns a negative mismatch count, so `<= 0` and `=== 0` are behaviourally identical; `=== 0` states the actual "no mismatches ⇒ no diff file" contract.

**`checkerboard` pixelmatch option**
`pixelmatchOptions.checkerboard` (`boolean`, default `true`) is forwarded to pixelmatch 7.2.0+ and validated as a boolean, closing the last gap in the public option surface. Added to the type, the adapter, validation, the README table, and the CHANGELOG.

**excluded-areas-builder coordinate clamp**
Drawing coordinates now clamp to the last valid pixel index (`naturalW - 1` / `naturalH - 1`), so emitted areas are valid **inclusive** pixel indices rather than one-past-the-edge.
⚠️ The tool pins a CSP `script-src` sha256 hash of its own inline `<script>`; editing the script invalidated that hash and the browser then blocked **all** JS (e2e tests 5+ timed out at 30s while tests 1–4 still passed on static HTML). The hash was regenerated to match. There is no generator script — it is hand-maintained.

## Bookkeeping
- RELI-06 and RELI-07 moved from `BACKLOG.md` → `BACKLOG-ARCHIVE.md` (with Impl/Rat).
- `CHANGELOG.md` `[Unreleased]` updated (Added / Changed / Fixed).
- `CODEMAP.md` regenerated (validateArea line shift).

## Test plan
- [x] `npm run test:unit` — 400/400 passing, **100% coverage** (statements/branches/functions/lines)
- [x] `npm run test:e2e` — 47/47 passing (Playwright, chromium)
- [x] typecheck + lint + format:check + license — all green
- [x] Red→green TDD: new data-driven negative-coordinate cases (sync + async) and checkerboard validation/adapter cases fail before the fix, pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)