### PR TITLE
chore: add readiness workflow updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
-name: Tests on push
+name: Tests
 on:
     push:
         branches-ignore:
             - 'release/*'
+    pull_request:
 permissions:
     contents: read
 jobs:

--- a/BACKLOG-ARCHIVE.md
+++ b/BACKLOG-ARCHIVE.md
@@ -75,3 +75,18 @@
 - [x] 🟡 🧪 TEST [TEST-01]: Fixture-free orchestrator tests (a+b)
     - **Impl:** New `__tests__/comparePng.logic.test.ts` (3 in-memory-buffer cases) + `__tests__/comparePng.ports.test.ts` (fake port injection). Sub-items: a (decision logic), b (port injection after API-01b).
     - **Rat:** Orchestration decision logic was only testable through real PNG decode + disk fixtures — slow and coupled logic tests to fixture maintenance.
+
+## 📝 Docs
+
+- [x] 🟡 📝 DOC [DOC-02]: Add `SECURITY.md` (disclosure channel)
+    - **Impl:** Added `SECURITY.md` with supported versions (`6.x`) and GitHub private vulnerability reporting guidance.
+    - **Rat:** Security reporters needed a clear disclosure path without relying on public issues or an unverified contact address.
+
+## 🛠️ Build · Deps · CI · DX
+
+- [x] 🟢 ♻️ DX [DX-03]: Add `test:fast` script (skip pretest chain)
+    - **Impl:** Added `npm run test:fast` as a direct verbose Vitest run without the unit-test preflight chain.
+    - **Rat:** Maintainers needed a documented fast iteration command that skips clean, lint, format, license, typecheck, and coverage gates.
+- [x] 🟢 ♻️ CI [CI-01]: Add `pull_request` trigger to `test.yml`
+    - **Impl:** Added `pull_request` to the main test workflow and renamed the workflow from push-only to `Tests`.
+    - **Rat:** PRs should run the existing cross-platform test matrix before merge, not only after branch pushes.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -63,7 +63,6 @@
 ## 📝 Docs
 
 - [ ] 🟡 📝 DOC [DOC-01]: Sweep stale RELI-03 frontmatter
-- [ ] 🟡 📝 DOC [DOC-02]: Add `SECURITY.md` (disclosure channel)
 - [ ] 🟢 📝 DOC [DOC-03]: Dedupe `CLAUDE.md` vs `.github/copilot-instructions.md`
 - [ ] 🟢 📝 DOC [DOC-04]: Expand public function JSDoc
 - [ ] 🟢 📝 DOC [DOC-05]: Cross-link `ARCHITECTURE.md` ↔ `BACKLOG.md`
@@ -81,10 +80,8 @@
 - [ ] 🟢 ♻️ DEPS [DEPS-03]: Loosen `peerDependencies` upper bounds (or watch script)
 - [ ] 🟢 ♻️ DX [DX-01]: Extract `scripts/open-tool.mjs` (kill inline `node -e`)
 - [ ] 🟢 ♻️ DX [DX-02]: Add `npm run dev` (vitest watch)
-- [ ] 🟢 ♻️ DX [DX-03]: Add `test:fast` script (skip pretest chain)
 - [ ] 🟢 ♻️ DX [DX-04]: Add `.editorconfig`
 - [ ] 🟢 ♻️ DX [DX-05]: Pre-commit hook (`simple-git-hooks` + `lint-staged`)
-- [ ] 🟢 ♻️ CI [CI-01]: Add `pull_request` trigger to `test.yml`
 - [ ] 🟢 ♻️ CI [CI-02]: Add CodeQL workflow
 - [ ] 🟢 ♻️ CI [CI-03]: `dependency-review-action` on PRs
 - [ ] 🟢 ♻️ CI [CI-04]: Upload coverage to Codecov

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 6.x     | Yes       |
+| < 6.0   | No        |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for suspected security vulnerabilities.
+
+Report vulnerabilities through GitHub's private vulnerability reporting or security advisory flow for this repository. Include:
+
+- Affected version
+- Impact and attack scenario
+- Reproduction steps or proof of concept
+- Any known mitigations
+
+Security reports are triaged before public disclosure. Fixes may be released as patch versions when the supported release line is affected.

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "test:docker": "npm run clean && npm run docker:build && npm run docker:run",
         "pretest:e2e": "npx playwright install chromium",
         "test:e2e": "playwright test",
+        "test:fast": "vitest run --reporter=verbose",
         "test:license": "node ./scripts/check-licenses.mjs",
         "pretest:unit": "npm run clean && npm run codemap:check && npm run lint && npm run format:check && npm run test:license && npm run typecheck",
         "test:unit": "VITEST_FULL_COVERAGE=true vitest run --coverage",


### PR DESCRIPTION
## Linked BACKLOG items

- DOC-02: Add `SECURITY.md` (disclosure channel)
- DX-03: Add `test:fast` script (skip pretest chain)
- CI-01: Add `pull_request` trigger to `test.yml`

## Backlog items intentionally excluded

- Runtime/security internals: SECU-04, SECU-05, SECU-09
- Public API changes: API-02 and API-03/API-04/API-05
- Architecture refactors: ARCH-09, ARCH-10, ARCH-12
- Public type cleanup: TYPE-04, TYPE-05, TYPE-06
- Other CI/DX/docs tasks outside this readiness slice

## Rationale

This is a low-risk readiness PR that improves disclosure guidance, fast local test iteration, and PR CI coverage before higher-risk runtime/API work begins.

## Architecture decisions

No runtime architecture changed. The changes are limited to repository metadata, CI trigger configuration, and documentation/backlog bookkeeping.

## Implementation summary

- Added `SECURITY.md` with supported versions limited to `6.x` and GitHub private vulnerability reporting guidance.
- Added `npm run test:fast` as a direct verbose Vitest run that skips the unit-test preflight chain.
- Added a `pull_request` trigger to the main test workflow and renamed the workflow from `Tests on push` to `Tests`.
- Moved completed backlog items from `BACKLOG.md` to `BACKLOG-ARCHIVE.md`.

## Testing summary

- `npm run format:check`
- `npm run typecheck`
- `npm run codemap:check`
- `npm run test:fast` (37 files, 400 tests passed)
- `npm run test` (37 unit test files / 400 tests passed with 100% coverage; 47 Playwright e2e tests passed)
- `npm run codemap` regenerated `CODEMAP.md`; no diff was produced.

## CLI changes

No package binary CLI changes. Package script surface now includes `npm run test:fast`.

## Skill changes

None. No repository-local skill bundle was found or modified.

## Documentation changes

Added `SECURITY.md` and archived the completed docs/DX/CI backlog items.

## Risk assessment

Low. This PR does not change runtime code, public APIs, dependencies, or published artifacts beyond repository metadata/documentation.

## Rollback strategy

Revert this PR. The changes are isolated to documentation, package scripts, CI trigger config, and backlog bookkeeping.

## Known limitations

- `SECURITY.md` intentionally omits email because no verified dedicated security contact exists in the repo.
- Only the current `6.x` release line is marked supported.

## Assumptions

- GitHub private vulnerability reporting / security advisories are the intended disclosure channel.
- Older major versions are not promised security support.
