### PR TITLE
fix: snapshot matcher correctness (#103, #98, #102)

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.2.0"
     },
-    "sourceHash": "86d91808ca03900278cedc6227b4a3b0582fa8ffe12a822578d57dd89e9ebf43",
+    "sourceHash": "8820f7f3c414148d9d1cac9b15f9754676107a6dd99e8a95c30951b65298a9f1",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -186,7 +186,7 @@ Schema: `codemap.v2`
             "kind": "function",
             "entrypoint": "src/jest.ts",
             "file": "src/jest.ts",
-            "line": 187,
+            "line": 180,
             "signature": "export function registerJestPngSnapshotMatcher(expect: ExpectLike): void",
             "jsdoc": null,
             "typeOnly": false
@@ -645,7 +645,7 @@ Schema: `codemap.v2`
                 {
                     "name": "JEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "kind": "const",
-                    "line": 9,
+                    "line": 8,
                     "exported": false,
                     "signature": "const JEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "members": null,
@@ -654,7 +654,7 @@ Schema: `codemap.v2`
                 {
                     "name": "ExpectLike",
                     "kind": "type",
-                    "line": 11,
+                    "line": 10,
                     "exported": false,
                     "signature": "type ExpectLike = { extend: (matchers: Record<string, unknown>) => void; };",
                     "members": null,
@@ -663,7 +663,7 @@ Schema: `codemap.v2`
                 {
                     "name": "SnapshotStateLike",
                     "kind": "type",
-                    "line": 15,
+                    "line": 14,
                     "exported": false,
                     "signature": "type SnapshotStateLike = { added?: number; expand?: boolean; matched?: number; unmatched?: number; updated?: number; markSnapshotsAsCheckedForTest?: (testName: string) => void; [key: string]: unknown;…",
                     "members": null,
@@ -672,7 +672,7 @@ Schema: `codemap.v2`
                 {
                     "name": "JestMatcherContext",
                     "kind": "type",
-                    "line": 25,
+                    "line": 24,
                     "exported": false,
                     "signature": "type JestMatcherContext = { currentConcurrentTestName?: () => string | undefined; currentTestName?: string; error?: Error; snapshotState?: SnapshotStateLike | null; testFailing?: boolean; };",
                     "members": null,
@@ -681,7 +681,7 @@ Schema: `codemap.v2`
                 {
                     "name": "addOuterLineBreaks",
                     "kind": "function",
-                    "line": 33,
+                    "line": 32,
                     "exported": false,
                     "signature": "function addOuterLineBreaks(value: string): string",
                     "members": null,
@@ -690,7 +690,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getSnapshotData",
                     "kind": "function",
-                    "line": 37,
+                    "line": 36,
                     "exported": false,
                     "signature": "function getSnapshotData(snapshotState: SnapshotStateLike): Record<string, string>",
                     "members": null,
@@ -699,7 +699,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getSnapshotCounters",
                     "kind": "function",
-                    "line": 47,
+                    "line": 46,
                     "exported": false,
                     "signature": "function getSnapshotCounters(snapshotState: SnapshotStateLike): Map<string, number>",
                     "members": null,
@@ -708,7 +708,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getUncheckedKeys",
                     "kind": "function",
-                    "line": 57,
+                    "line": 56,
                     "exported": false,
                     "signature": "function getUncheckedKeys(snapshotState: SnapshotStateLike): Set<string>",
                     "members": null,
@@ -717,25 +717,16 @@ Schema: `codemap.v2`
                 {
                     "name": "getUpdateSnapshotMode",
                     "kind": "function",
-                    "line": 67,
+                    "line": 66,
                     "exported": false,
                     "signature": "function getUpdateSnapshotMode(snapshotState: SnapshotStateLike): 'all' | 'new' | 'none'",
                     "members": null,
                     "jsdoc": null
                 },
                 {
-                    "name": "getSnapshotPath",
-                    "kind": "function",
-                    "line": 77,
-                    "exported": false,
-                    "signature": "function getSnapshotPath(snapshotState: SnapshotStateLike): string | undefined",
-                    "members": null,
-                    "jsdoc": null
-                },
-                {
                     "name": "setSnapshotDirty",
                     "kind": "function",
-                    "line": 82,
+                    "line": 76,
                     "exported": false,
                     "signature": "function setSnapshotDirty(snapshotState: SnapshotStateLike): void",
                     "members": null,
@@ -744,7 +735,7 @@ Schema: `codemap.v2`
                 {
                     "name": "incrementSnapshotCounter",
                     "kind": "function",
-                    "line": 86,
+                    "line": 80,
                     "exported": false,
                     "signature": "function incrementSnapshotCounter(snapshotState: SnapshotStateLike, field: 'added' | 'matched' | 'unmatched' | 'updated'): void",
                     "members": null,
@@ -753,7 +744,7 @@ Schema: `codemap.v2`
                 {
                     "name": "resolveSnapshotKey",
                     "kind": "function",
-                    "line": 91,
+                    "line": 85,
                     "exported": false,
                     "signature": "function resolveSnapshotKey(snapshotState: SnapshotStateLike, testName: string): { count: number; key: string }",
                     "members": null,
@@ -762,7 +753,7 @@ Schema: `codemap.v2`
                 {
                     "name": "createJestMismatchMessage",
                     "kind": "function",
-                    "line": 101,
+                    "line": 95,
                     "exported": false,
                     "signature": "function createJestMismatchMessage(testName: string, mismatchedPixels: number): string",
                     "members": null,
@@ -771,7 +762,7 @@ Schema: `codemap.v2`
                 {
                     "name": "createJestMissingSnapshotMessage",
                     "kind": "function",
-                    "line": 108,
+                    "line": 102,
                     "exported": false,
                     "signature": "function createJestMissingSnapshotMessage(testName: string): string",
                     "members": null,
@@ -780,7 +771,7 @@ Schema: `codemap.v2`
                 {
                     "name": "persistJestSnapshot",
                     "kind": "function",
-                    "line": 114,
+                    "line": 108,
                     "exported": false,
                     "signature": "function persistJestSnapshot(snapshotState: SnapshotStateLike, key: string, serializedSnapshot: string): void",
                     "members": null,
@@ -789,7 +780,7 @@ Schema: `codemap.v2`
                 {
                     "name": "toMatchPngSnapshot",
                     "kind": "const",
-                    "line": 119,
+                    "line": 113,
                     "exported": false,
                     "signature": "const toMatchPngSnapshot",
                     "members": null,
@@ -798,7 +789,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getGlobalExpect",
                     "kind": "function",
-                    "line": 183,
+                    "line": 176,
                     "exported": false,
                     "signature": "function getGlobalExpect(): ExpectLike | undefined",
                     "members": null,
@@ -807,7 +798,7 @@ Schema: `codemap.v2`
                 {
                     "name": "registerJestPngSnapshotMatcher",
                     "kind": "function",
-                    "line": 187,
+                    "line": 180,
                     "exported": true,
                     "signature": "export function registerJestPngSnapshotMatcher(expect: ExpectLike): void",
                     "members": null,
@@ -816,7 +807,7 @@ Schema: `codemap.v2`
                 {
                     "name": "jestExpect",
                     "kind": "const",
-                    "line": 194,
+                    "line": 187,
                     "exported": false,
                     "signature": "const jestExpect",
                     "members": null,
@@ -826,8 +817,7 @@ Schema: `codemap.v2`
             "imports": [
                 "./matchers/createPngSnapshotMatcher",
                 "./matchers/pngSnapshot",
-                "./types",
-                "node:fs"
+                "./types"
             ],
             "reExports": []
         },

--- a/__tests__/pngSnapshotMatcher.test.ts
+++ b/__tests__/pngSnapshotMatcher.test.ts
@@ -116,10 +116,7 @@ describe('createPngSnapshotMatcher', () => {
     test('rejects .not because snapshot negation is unsupported', () => {
         const matcher = createPngSnapshotMatcher(() => ({ pass: true, message: () => '' }));
 
-        const result = expectSyncResult(matcher.call({ isNot: true }, readFileSync(PNG_FILE)));
-
-        expect(result.pass).toBe(false);
-        expect(result.message()).toContain('.not.toMatchPngSnapshot() is not supported');
+        expect(() => matcher.call({ isNot: true }, readFileSync(PNG_FILE))).toThrow('.not.toMatchPngSnapshot() is not supported.');
     });
 
     test.each([
@@ -278,6 +275,15 @@ describe('vitest matcher entrypoint', () => {
         await import('../src/vitest.mjs');
 
         expect(extendSpy).not.toHaveBeenCalled();
+    });
+
+    test('rejects a real expect().not.toMatchPngSnapshot() assertion driven through Vitest', async () => {
+        vi.resetModules();
+        clearMatcherRegistration();
+
+        await import('../src/vitest.mjs');
+
+        expect(() => expect(readFileSync(PNG_FILE)).not.toMatchPngSnapshot()).toThrow('.not.toMatchPngSnapshot() is not supported.');
     });
 
     test('compares stored Vitest PNG snapshots with ComparePngOptions', async () => {
@@ -738,6 +744,34 @@ describe('jest matcher entrypoint', () => {
         expect(result.message()).toContain('New PNG snapshot was not written for "creates snapshot"');
     });
 
+    test('counts a missing Jest PNG snapshot as unmatched in CI (none) mode', async () => {
+        vi.resetModules();
+        const extend = vi.fn();
+        (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
+
+        await import('../src/jest.js');
+
+        const registeredMatchers = extend.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Jest matcher to be registered');
+        }
+
+        const snapshotState = createJestSnapshotState({});
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call(
+                {
+                    currentTestName: 'missing snapshot in CI',
+                    snapshotState,
+                } as never,
+                readFileSync(PNG_FILE),
+            ),
+        );
+
+        expect(result.pass).toBe(false);
+        expect(snapshotState.unmatched).toBe(1);
+    });
+
     test('returns a generic missing-snapshot message when no Jest test name is available', async () => {
         vi.resetModules();
         const extend = vi.fn();
@@ -764,7 +798,7 @@ describe('jest matcher entrypoint', () => {
         expect(result.message()).toBe('New PNG snapshot was not written. Run Jest with -u to create it.');
     });
 
-    test('does not create a new Jest PNG snapshot when a snapshot file already exists', async () => {
+    test('creates a new Jest PNG snapshot key under -u even when the snapshot file already exists', async () => {
         vi.resetModules();
         const extend = vi.fn();
         (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
@@ -777,25 +811,30 @@ describe('jest matcher entrypoint', () => {
             throw new Error('Expected the Jest matcher to be registered');
         }
 
+        const snapshotState = {
+            _counters: new Map<string, number>(),
+            _dirty: false,
+            _snapshotData: {} as Record<string, string>,
+            _snapshotPath: PNG_FILE,
+            _uncheckedKeys: new Set<string>(),
+            _updateSnapshot: 'new',
+            added: 0,
+        };
         const result = expectSyncResult(
             registeredMatchers.toMatchPngSnapshot.call(
                 {
                     currentTestName: 'existing snapshot file',
-                    snapshotState: {
-                        _counters: new Map<string, number>(),
-                        _dirty: false,
-                        _snapshotData: {},
-                        _snapshotPath: PNG_FILE,
-                        _uncheckedKeys: new Set<string>(),
-                        _updateSnapshot: 'new',
-                    },
+                    snapshotState,
                 } as never,
                 readFileSync(PNG_FILE),
             ),
         );
 
-        expect(result.pass).toBe(false);
-        expect(result.message()).toContain('New PNG snapshot was not written for "existing snapshot file"');
+        expect(result.pass).toBe(true);
+        expect(result.message()).toBe('');
+        expect(snapshotState.added).toBe(1);
+        expect(snapshotState._dirty).toBe(true);
+        expect(snapshotState._snapshotData).toHaveProperty('existing snapshot file 1');
     });
 
     test('initializes Jest snapshot counters when they are missing', async () => {

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -1,7 +1,6 @@
 /**
  * @sideEffect Registers a `toMatchPngSnapshot` matcher on Jest's global `expect` when present, and augments the global `jest.Matchers` interface.
  */
-import { existsSync } from 'node:fs';
 import type { ComparePngOptions } from './types';
 import { createPngSnapshotMatcher } from './matchers/createPngSnapshotMatcher';
 import { buildSnapshotTestName, compareAgainstSerializedPngSnapshot, serializePngSnapshot } from './matchers/pngSnapshot';
@@ -74,11 +73,6 @@ function getUpdateSnapshotMode(snapshotState: SnapshotStateLike): 'all' | 'new' 
     return updateSnapshot;
 }
 
-function getSnapshotPath(snapshotState: SnapshotStateLike): string | undefined {
-    const snapshotPath = snapshotState._snapshotPath;
-    return typeof snapshotPath === 'string' ? snapshotPath : undefined;
-}
-
 function setSnapshotDirty(snapshotState: SnapshotStateLike): void {
     snapshotState._dirty = true;
 }
@@ -131,8 +125,6 @@ const toMatchPngSnapshot = createPngSnapshotMatcher((matcherContext, received, a
     const snapshotData = getSnapshotData(snapshotState);
     const storedSnapshot = snapshotData[key];
     const updateSnapshot = getUpdateSnapshotMode(snapshotState);
-    const snapshotPath = getSnapshotPath(snapshotState);
-    const snapshotIsPersisted = storedSnapshot !== undefined || (snapshotPath !== undefined && existsSync(snapshotPath));
 
     if (storedSnapshot !== undefined) {
         const comparison = compareAgainstSerializedPngSnapshot(received, storedSnapshot, args.options);
@@ -163,7 +155,7 @@ const toMatchPngSnapshot = createPngSnapshotMatcher((matcherContext, received, a
         };
     }
 
-    if ((updateSnapshot === 'new' || updateSnapshot === 'all') && !snapshotIsPersisted) {
+    if (updateSnapshot === 'new' || updateSnapshot === 'all') {
         persistJestSnapshot(snapshotState, key, serializePngSnapshot(received));
         incrementSnapshotCounter(snapshotState, 'added');
         return {
@@ -172,6 +164,7 @@ const toMatchPngSnapshot = createPngSnapshotMatcher((matcherContext, received, a
         };
     }
 
+    incrementSnapshotCounter(snapshotState, 'unmatched');
     return {
         pass: false,
         actual: serializePngSnapshot(received),

--- a/src/matchers/createPngSnapshotMatcher.ts
+++ b/src/matchers/createPngSnapshotMatcher.ts
@@ -58,10 +58,7 @@ export function createPngSnapshotMatcher(delegate: SnapshotMatcherDelegate) {
         options?: ComparePngOptions,
     ) {
         if (this.isNot === true) {
-            return {
-                pass: false,
-                message: () => '.not.toMatchPngSnapshot() is not supported.',
-            };
+            throw new Error('.not.toMatchPngSnapshot() is not supported.');
         }
 
         if (!(received instanceof Uint8Array) || !hasPngSignature(received)) {


### PR DESCRIPTION
## Summary

Fixes three defects on the shared PNG snapshot-matcher path (Vitest + Jest):

- **#103 (Medium)** — `expect(png).not.toMatchPngSnapshot()` *silently passed* instead of being rejected. The `isNot` guard returned `pass: false`, which a matcher framework interprets as a **successful** negated assertion, so the dead `".not … is not supported."` branch never fired and no comparison ran (a permanent false-green). It now **throws**, genuinely rejecting `.not` in both frameworks — matching the README contract and Jest's own `toMatchSnapshot` behavior.
- **#98 (High)** — under `jest -u`, a **new** snapshot key was refused whenever the spec's `.snap` file already existed, because the new-key write was gated on **file** existence (`existsSync`) rather than **key** existence. You couldn't add a second `toMatchPngSnapshot()` to a spec without it failing, and `-u` didn't help. Now gated on key absence per Jest's `SnapshotState` semantics; the dead `existsSync`/`getSnapshotPath`/`snapshotIsPersisted` path is removed.
- **#102 (Low)** — a missing snapshot in CI (`none` mode) correctly returned `pass: false` but never incremented `snapshotState.unmatched`, so the `Snapshots: N failed` summary undercounted. Now tallied, mirroring the pixel-mismatch path.

## Why these are together
All three live on the `createPngSnapshotMatcher` → `jest.ts` delegate path; #98 and #102 are in the same function (doing #98 first makes the `none`/CI terminal return that #102 fixes unambiguous).

## Test plan
- [x] Flipped the codifying tests that locked in the bugs: `pngSnapshotMatcher.test.ts` `.not` (raw-result → **throws**) and the `-u` + existing-`.snap` + new-key case (now **writes**, `added===1`, `_dirty`).
- [x] Added an **end-to-end** `expect(png).not.toMatchPngSnapshot()` driven through Vitest — closing the blind spot (raw-result-only assertion) that let #103 regress.
- [x] Added a #102 regression: `none`-mode missing snapshot → `pass:false` **and** `unmatched===1`.
- [x] `npm run test:unit` — 402 tests, **100%** coverage (lines/branches/functions/statements).
- [x] `npm run test:e2e` — 47 passed.
- [x] lint / format:check / license / typecheck / codemap:check all green (CODEMAP regenerated; version unchanged at 6.2.0).

Closes #103
Closes #98
Closes #102