### PR TITLE
fix: accurate invalid-input message and maxPixels default doc (#100, #99)

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.2.0"
     },
-    "sourceHash": "8820f7f3c414148d9d1cac9b15f9754676107a6dd99e8a95c30951b65298a9f1",
+    "sourceHash": "14a28028fcd6a9b4d47247d24f55aca08e04d4ca979f7e5c7604c4fc6166f999",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -166,7 +166,7 @@ Schema: `codemap.v2`
             "kind": "function",
             "entrypoint": "src/index.ts",
             "file": "src/comparePngAsync.ts",
-            "line": 27,
+            "line": 28,
             "signature": "export async function comparePngAsync(png1: string | Buffer, png2: string | Buffer, opts?: ComparePngOptions): Promise<number>",
             "jsdoc": null,
             "typeOnly": false
@@ -311,7 +311,7 @@ Schema: `codemap.v2`
                 {
                     "name": "loadSourcesAsync",
                     "kind": "function",
-                    "line": 13,
+                    "line": 14,
                     "exported": false,
                     "signature": "async function loadSourcesAsync( png1: string | Buffer, png2: string | Buffer, opts: ReturnType<typeof resolveOptions>, ): Promise<LoadedSources>",
                     "members": null,
@@ -320,7 +320,7 @@ Schema: `codemap.v2`
                 {
                     "name": "comparePngAsync",
                     "kind": "function",
-                    "line": 27,
+                    "line": 28,
                     "exported": true,
                     "signature": "export async function comparePngAsync(png1: string | Buffer, png2: string | Buffer, opts?: ComparePngOptions): Promise<number>",
                     "members": null,
@@ -329,6 +329,7 @@ Schema: `codemap.v2`
             ],
             "imports": [
                 "./errors",
+                "./pipeline/describeInvalidSources",
                 "./pipeline/normalizeImages",
                 "./pipeline/persistDiff",
                 "./pipeline/resolveOptions",
@@ -1032,12 +1033,48 @@ Schema: `codemap.v2`
             "reExports": []
         },
         {
+            "path": "src/pipeline/describeInvalidSources.ts",
+            "symbols": [
+                {
+                    "name": "InvalidPngReason",
+                    "kind": "type",
+                    "line": 3,
+                    "exported": false,
+                    "signature": "type InvalidPngReason = Extract<LoadedPng, { kind: 'invalid' }>['reason'];",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
+                    "name": "INVALID_PNG_REASON_PHRASES",
+                    "kind": "const",
+                    "line": 5,
+                    "exported": false,
+                    "signature": "const INVALID_PNG_REASON_PHRASES: Record<InvalidPngReason, string> = { decode: 'could not decode PNG content', path: 'source path could not be loaded', type: 'unrecognized input type', }",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
+                    "name": "describeBothInvalidSources",
+                    "kind": "function",
+                    "line": 22,
+                    "exported": true,
+                    "signature": "export function describeBothInvalidSources(firstReason: InvalidPngReason, secondReason: InvalidPngReason): string",
+                    "members": null,
+                    "jsdoc": "Builds the error message used when both PNG inputs fail to load. Reports each input's actual failure reason (invalid content vs. unloadable path vs. unknown type) instead of the misleading \"Unknown PNG files input type\", which wrongly implies the input *type* was unrecognised even for valid `Buffer`/`string` inputs whose content simply could not be decoded."
+                }
+            ],
+            "imports": [
+                "../types/png.data"
+            ],
+            "reExports": []
+        },
+        {
             "path": "src/pipeline/loadSources.ts",
             "symbols": [
                 {
                     "name": "loadSources",
                     "kind": "function",
-                    "line": 6,
+                    "line": 7,
                     "exported": true,
                     "signature": "export function loadSources(png1: string | Buffer, png2: string | Buffer, opts: ResolvedOptions): LoadedSources",
                     "members": null,
@@ -1047,6 +1084,7 @@ Schema: `codemap.v2`
             "imports": [
                 "../errors",
                 "../ports/fsImageSource",
+                "./describeInvalidSources",
                 "./types",
                 "node:buffer"
             ],

--- a/__tests__/comparePng.exceptions.test.ts
+++ b/__tests__/comparePng.exceptions.test.ts
@@ -454,7 +454,7 @@ test('with throwErrorOnInvalidInputData=false, zero-dimension PNG is treated as 
         expectThrownAs(
             () => comparePng(Buffer.alloc(24), Buffer.alloc(24), { throwErrorOnInvalidInputData: false }),
             InvalidInputError,
-            'Unknown PNG files input type',
+            'Both PNG inputs are invalid — png1: could not decode PNG content; png2: could not decode PNG content.',
         );
     } finally {
         readSpy.mockRestore();

--- a/__tests__/comparePngAsync.exceptions.test.ts
+++ b/__tests__/comparePngAsync.exceptions.test.ts
@@ -465,7 +465,7 @@ test('[async] with throwErrorOnInvalidInputData=false, zero-dimension PNG is tre
         await expectThrownAs(
             () => comparePngAsync(Buffer.alloc(24), Buffer.alloc(24), { throwErrorOnInvalidInputData: false }),
             InvalidInputError,
-            'Unknown PNG files input type',
+            'Both PNG inputs are invalid — png1: could not decode PNG content; png2: could not decode PNG content.',
         );
     } finally {
         readSpy.mockRestore();

--- a/__tests__/describeInvalidSources.test.ts
+++ b/__tests__/describeInvalidSources.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+import { describeBothInvalidSources } from '../src/pipeline/describeInvalidSources';
+
+describe('describeBothInvalidSources', () => {
+    test.each([
+        {
+            first: 'decode',
+            second: 'decode',
+            expected: 'Both PNG inputs are invalid — png1: could not decode PNG content; png2: could not decode PNG content.',
+        },
+        {
+            first: 'path',
+            second: 'path',
+            expected: 'Both PNG inputs are invalid — png1: source path could not be loaded; png2: source path could not be loaded.',
+        },
+        {
+            first: 'type',
+            second: 'type',
+            expected: 'Both PNG inputs are invalid — png1: unrecognized input type; png2: unrecognized input type.',
+        },
+        {
+            first: 'decode',
+            second: 'path',
+            expected: 'Both PNG inputs are invalid — png1: could not decode PNG content; png2: source path could not be loaded.',
+        },
+    ] as const)('maps $first/$second reasons to an accurate message', ({ first, second, expected }) => {
+        expect(describeBothInvalidSources(first, second)).toBe(expected);
+    });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,7 +106,7 @@ Loads both inputs via the selected `ImageSourcePort`:
 - default sync implementation: `fsImageSource`
 - default async implementation: `fsAsyncImageSource`
 
-If both sides are invalid, the pipeline throws `InvalidInputError('Unknown PNG files input type')`.
+If both sides are invalid, the pipeline throws `InvalidInputError` with a message naming each input's failure reason (e.g. `Both PNG inputs are invalid — png1: could not decode PNG content; png2: source path could not be loaded.`).
 
 ### 3. `normalizeImages`
 

--- a/src/comparePngAsync.ts
+++ b/src/comparePngAsync.ts
@@ -8,6 +8,7 @@ import { fsAsyncDiffWriter } from './ports/fsAsyncDiffWriter';
 import { fsAsyncImageSource } from './ports/fsAsyncImageSource';
 import type { ComparePngOptions } from './types';
 import type { LoadedSources } from './pipeline/types';
+import { describeBothInvalidSources } from './pipeline/describeInvalidSources';
 import { InvalidInputError } from './errors';
 
 async function loadSourcesAsync(
@@ -18,7 +19,7 @@ async function loadSourcesAsync(
     const [first, second] = await Promise.all([fsAsyncImageSource.load(png1, opts), fsAsyncImageSource.load(png2, opts)]);
 
     if (first.kind === 'invalid' && second.kind === 'invalid') {
-        throw new InvalidInputError('Unknown PNG files input type');
+        throw new InvalidInputError(describeBothInvalidSources(first.reason, second.reason));
     }
 
     return { png1, png2, first, second };

--- a/src/pipeline/describeInvalidSources.ts
+++ b/src/pipeline/describeInvalidSources.ts
@@ -1,0 +1,24 @@
+import type { LoadedPng } from '../types/png.data';
+
+type InvalidPngReason = Extract<LoadedPng, { kind: 'invalid' }>['reason'];
+
+const INVALID_PNG_REASON_PHRASES: Record<InvalidPngReason, string> = {
+    decode: 'could not decode PNG content',
+    path: 'source path could not be loaded',
+    type: 'unrecognized input type',
+};
+
+/**
+ * Builds the error message used when both PNG inputs fail to load. Reports each
+ * input's actual failure reason (invalid content vs. unloadable path vs. unknown
+ * type) instead of the misleading "Unknown PNG files input type", which wrongly
+ * implies the input *type* was unrecognised even for valid `Buffer`/`string`
+ * inputs whose content simply could not be decoded.
+ *
+ * The `path` phrasing intentionally stays generic ("could not be loaded") rather
+ * than "file not found": `reason: 'path'` also covers unreadable files, ENOTDIR,
+ * and path-validation failures, mirroring the VUL-05 messaging in getPngData.
+ */
+export function describeBothInvalidSources(firstReason: InvalidPngReason, secondReason: InvalidPngReason): string {
+    return `Both PNG inputs are invalid — png1: ${INVALID_PNG_REASON_PHRASES[firstReason]}; png2: ${INVALID_PNG_REASON_PHRASES[secondReason]}.`;
+}

--- a/src/pipeline/loadSources.ts
+++ b/src/pipeline/loadSources.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { InvalidInputError } from '../errors';
 import { fsImageSource } from '../ports/fsImageSource';
+import { describeBothInvalidSources } from './describeInvalidSources';
 import type { LoadedSources, ResolvedOptions } from './types';
 
 export function loadSources(png1: string | Buffer, png2: string | Buffer, opts: ResolvedOptions): LoadedSources {
@@ -9,7 +10,7 @@ export function loadSources(png1: string | Buffer, png2: string | Buffer, opts: 
     const second = imageSource.load(png2, opts);
 
     if (first.kind === 'invalid' && second.kind === 'invalid') {
-        throw new InvalidInputError('Unknown PNG files input type');
+        throw new InvalidInputError(describeBothInvalidSources(first.reason, second.reason));
     }
 
     return { png1, png2, first, second };

--- a/src/types/compare.options.ts
+++ b/src/types/compare.options.ts
@@ -130,7 +130,7 @@ export type ComparePngOptions = {
      * (e.g., 1 × 16,777,216 pixels) that would still exhaust memory.
      * Set to `Infinity` to disable the limit entirely.
      *
-     * @default 16_777_216 (256 megapixels, ~1 GB decompressed at 4 bytes/pixel)
+     * @default 16_777_216 (16 megapixels, ~64 MB decompressed at 4 bytes/pixel)
      * @example
      * ```ts
      * // For web/mobile use cases with strict memory budgets


### PR DESCRIPTION
## Summary

Two diagnostic/documentation correctness fixes:

- **#100 (Low)** — when both PNG inputs fail to load, the pipeline threw `InvalidInputError('Unknown PNG files input type')`. But the *type* (`Buffer`/`string`) is valid per the public signature — it's the **content** (undecodable) or **path** (missing) that failed, so the message sent developers down the wrong diagnostic path. `loadSources` and `comparePngAsync` now build the message from each input's actual failure reason (`decode` / `path` / `type`) via a shared `describeBothInvalidSources` helper, e.g. `Both PNG inputs are invalid — png1: could not decode PNG content; png2: file not found.` Behaviour is otherwise unchanged (still throws `InvalidInputError`).
- **#99 (Medium)** — the `maxPixels` `@default` JSDoc claimed *256 megapixels (~1 GB)*, but `DEFAULT_MAX_PIXELS` is `16_777_216` = **16 megapixels (~64 MB)**. A caller trusting the doc would size images against a ceiling 16× too high and hit an unexpected `ResourceLimitError`. Corrected the description; the constant and runtime are untouched.

## Test plan
- [x] RED→GREEN: flipped the two `*.exceptions.test.ts` assertions that codified the old "Unknown PNG files input type" string to the new reason-aware message.
- [x] New `describeInvalidSources.test.ts` unit test covering all three reason phrases (`decode`/`path`/`type`) and a mixed pair — proving the per-input mapping, which the decode/decode integration tests alone don't.
- [x] Updated `docs/ARCHITECTURE.md`, which documented the old message.
- [x] #99 is documentation-only (JSDoc string); no runtime or test change needed.
- [x] `npm run test:unit` — 404 tests, **100%** coverage; lint / format / license / typecheck / codemap:check green (CODEMAP regenerated; version unchanged at 6.2.0).

Closes #100
Closes #99