### PR TITLE
Release 6.2.0 + npm Trusted Publishing (OIDC) and release checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
     release:
         types: [published]
 
+# id-token: write is required for npm Trusted Publishing (OIDC) and provenance.
+# No NPM_TOKEN is used: the trusted publisher must be configured on npmjs.com
+# (Package → Settings → Trusted Publishing) for org "dichovsky", repo
+# "png-visual-compare", workflow "publish.yml", no environment.
 permissions:
     contents: read
     id-token: write
@@ -23,10 +27,17 @@ jobs:
                   node-version-file: .nvmrc
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
+            - name: Ensure npm supports Trusted Publishing (>= 11.5.1)
+              run: npm install -g npm@latest
             - run: npm ci
             - run: npx playwright install --with-deps chromium
             - run: npm audit --audit-level=high
             - run: npm run build
-            - run: npm publish --provenance
+            - name: Pre-release checks
+              run: npm run release:check:pre
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+            - name: Publish to npm (Trusted Publishing / OIDC)
+              run: npm publish --provenance
+            - name: Post-release checks
+              run: npm run release:check:post

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+npm run build          # compile TypeScript → ./out via tsconfig.prod.json (runs clean first via prebuild)
+npm run clean          # delete ./out, ./coverage, ./test-results
+npm run lint           # ESLint with @typescript-eslint
+npm run typecheck      # typecheck the full repo via tsconfig.json (src, tests, e2e, configs)
+npm run test:unit      # unit-test gate: clean → lint → format:check → license check → typecheck → repo-wide vitest coverage
+npm run test:e2e       # Playwright e2e tests for the Excluded Areas Builder
+npm run test           # full test suite: repo-wide unit coverage gate plus Playwright e2e tests
+npm run test:license   # check all production dependency licenses are in the approved list
+npm run codemap        # regenerate CODEMAP.md via scripts/generate-codemap.mjs
+npm run format         # format files with Prettier
+npm run format:check   # validate formatting with Prettier
+```
+
+Run a single test file (skips pretest steps):
+
+```sh
+npx vitest run __tests__/comparePng.test.ts
+```
+
+Run tests matching a name pattern:
+
+```sh
+npx vitest run --reporter=verbose -t "compare PNG with text"
+```
+
+Watch mode during development:
+
+```sh
+npx vitest --reporter=verbose
+```
+
+Update snapshots:
+
+```sh
+npx vitest run --update-snapshots
+```
+
+> Use `npx vitest run` directly to skip clean/lint/format:check/build when iterating quickly.
+> `npm run test:unit` enables the repo-wide 100% coverage gate; direct `npx vitest run ... --coverage` commands only report coverage for the files exercised by that focused run.
+
+## Architecture
+
+This repository now has two public runtime APIs:
+
+- `comparePng(...)` — sync orchestration
+- `comparePngAsync(...)` — async filesystem-backed orchestration
+
+Both APIs share the same pipeline:
+
+1. `resolveOptions`
+2. `loadSources` / `loadSourcesAsync`
+3. `normalizeImages`
+4. `runComparison`
+5. `persistDiff`
+
+`comparePng.ts` should remain orchestration-only. Detailed architecture lives in `docs/ARCHITECTURE.md`.
+
+### Source layout
+
+```
+src/
+  index.ts                    # exports comparePng, comparePngAsync, errors, constants, and public types
+  comparePng.ts               # sync orchestrator
+  comparePngAsync.ts          # async orchestrator
+  pipeline/                   # option resolution, loading, normalization, comparison, diff persistence
+  ports/                      # sync/async filesystem adapters and test seams
+  adapters/                   # public-to-external library boundaries
+  getPngData.ts               # decodes image sources into LoadedPng
+  validate*.ts                # path, area, color, and pixelmatch option validation
+  types/                      # one type per file; collected in types/index.ts
+```
+
+### Pixel address formula (used throughout)
+
+```ts
+position = (image.width * y + x) * 4; // R=[pos], G=[pos+1], B=[pos+2], A=[pos+3]
+```
+
+## Key Conventions
+
+- **Tests import from `../src`**, not `../out` (compiled output)
+- **Data-driven test pattern**: all `comparePng.*` tests use a `testDataArray` loop — add new cases as array entries, not standalone `test()` calls
+- **Snapshot tests** in `comparePng.diffs.test.ts` and `comparePng.pixelmatch-options.test.ts` use `toMatchSnapshot()` on raw diff PNG buffers; snapshots are committed in `__tests__/__snapshots__/`
+- **One type per file** in `src/types/`; imports within `src/` use extensionless relative paths
+- **No test helper modules** — each test file is self-contained
+- **Coverage thresholds**: 100% lines/functions/statements/branches; `src/types/**/*` is excluded
+- **All production dependencies must use an approved license**: `ISC`, `MIT`, `MIT OR X11`, `BSD`, `Apache-2.0`, `Unlicense` — enforced by `npm run test:license` (part of `npm test`)
+- **Only `./out` is published** to npm (controlled by `"files": ["./out"]`)
+- **TypeScript config split**: use `tsconfig.json` for dev-wide no-emit typechecking and `tsconfig.prod.json` for emitted package builds
+
+## Mistake Logging
+
+Log one compact event per mistake (20-40 tokens, no filler):
+
+```text
+Ctx:
+Err:
+Cause:
+Fix:
+Rule:
+```
+
+Store project-specific mistakes in `.Codex/memory/` (session files are gitignored — see `.Codex/memory/README.md`); generalizable rules in global memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-06-19
+
 ### Added
 
 - **checkerboard** — `pixelmatchOptions.checkerboard` is now forwarded to
   pixelmatch (7.2.0+), letting callers control whether semi-transparent pixels
   are blended against a checkerboard pattern (`true`, the default) or plain
   white (`false`). Validated as a boolean by `validatePixelmatchOptions`.
+- **RELI-10** — New public `ComparisonError` (`code: 'ERR_COMPARISON'`) thrown
+  when the underlying `pixelmatch` call fails. The original failure is preserved
+  on the standard ES2022 `cause` property so callers can match by class or by
+  `code` instead of parsing free-form messages. Like `ResourceLimitError`, this
+  error is **not** downgraded by `throwErrorOnInvalidInputData: false` — a
+  comparison-kernel failure signals an integrity bug, not a recoverable input
+  problem. Applies to both `comparePng` and `comparePngAsync` since they share
+  `runComparison`.
 
 ### Changed
 
@@ -32,8 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **excluded-areas-builder** — the drawing tool now clamps coordinates to the
   last valid pixel index (`naturalW - 1` / `naturalH - 1`), so emitted areas
   are valid inclusive pixel indices instead of one-past-the-edge values.
-
-## [6.2.0] - 2026-06-03
+- `excludedAreas` are now painted on the final normalized canvas, _after_ size
+  extension, so an excluded band that falls outside the smaller image is no
+  longer clamped away and reported as a mismatch. Same-size inputs are
+  unaffected.
+- The `./vitest` subpath export no longer ships an empty CommonJS
+  `vitest.types.js`; the `declare module 'vitest'` augmentation is inlined into
+  `vitest.mts`, and the published types entry points to the co-located `.d.mts`.
 
 ### Security
 
@@ -57,27 +72,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (which can write fewer bytes than requested) with `writeFileSync`, which loops
   until the full buffer is flushed. The async path already guaranteed
   full-buffer writes via `FileHandle.writeFile`.
-
-### Added
-
-- **RELI-10** — New public `ComparisonError` (`code: 'ERR_COMPARISON'`) thrown
-  when the underlying `pixelmatch` call fails. The original failure is preserved
-  on the standard ES2022 `cause` property so callers can match by class or by
-  `code` instead of parsing free-form messages. Like `ResourceLimitError`, this
-  error is **not** downgraded by `throwErrorOnInvalidInputData: false` — a
-  comparison-kernel failure signals an integrity bug, not a recoverable input
-  problem. Applies to both `comparePng` and `comparePngAsync` since they share
-  `runComparison`.
-
-### Fixed
-
-- `excludedAreas` are now painted on the final normalized canvas, _after_ size
-  extension, so an excluded band that falls outside the smaller image is no
-  longer clamped away and reported as a mismatch. Same-size inputs are
-  unaffected.
-- The `./vitest` subpath export no longer ships an empty CommonJS
-  `vitest.types.js`; the `declare module 'vitest'` augmentation is inlined into
-  `vitest.mts`, and the published types entry points to the co-located `.d.mts`.
 
 ## [6.1.1] - 2026-05-16
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "prepublishOnly": "npm test && npm run build",
+        "release:check:pre": "node ./scripts/prerelease-check.mjs",
+        "release:check:post": "node ./scripts/postrelease-check.mjs",
         "test": "npm run test:unit && npm run test:e2e",
         "test:docker": "npm run clean && npm run docker:build && npm run docker:run",
         "pretest:e2e": "npx playwright install chromium",

--- a/scripts/postrelease-check.mjs
+++ b/scripts/postrelease-check.mjs
@@ -1,0 +1,166 @@
+/**
+ * Post-release verification for png-visual-compare.
+ *
+ * Runs AFTER `npm publish` (last step of `.github/workflows/publish.yml`, and
+ * runnable locally via `npm run release:check:post`). Confirms the version the
+ * repository claims is actually live, correct, and consumable on npm:
+ *   1. the version resolves on the registry,
+ *   2. the `latest` dist-tag points at it,
+ *   3. it carries a provenance attestation (Trusted Publishing / --provenance),
+ *   4. a freshly-installed copy imports and exposes the public API.
+ *
+ * Each registry check retries to absorb CDN propagation lag right after publish.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const { name, version } = pkg;
+
+const MAX_ATTEMPTS = 6;
+const RETRY_DELAY_MS = 10_000;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function npm(args, options = {}) {
+    return spawnSync('npm', args, { encoding: 'utf8', ...options });
+}
+
+/**
+ * Retry `attempt` (a sync predicate returning boolean) until it returns true or
+ * attempts run out, sleeping between tries to absorb registry propagation lag.
+ *
+ * @param {string} label
+ * @param {() => boolean} attempt
+ * @returns {Promise<boolean>}
+ */
+async function withRetry(label, attempt) {
+    for (let i = 1; i <= MAX_ATTEMPTS; i += 1) {
+        if (attempt()) return true;
+        if (i < MAX_ATTEMPTS) {
+            process.stdout.write(`  …${label}: attempt ${i}/${MAX_ATTEMPTS} not ready, retrying in ${RETRY_DELAY_MS / 1000}s\n`);
+            await delay(RETRY_DELAY_MS);
+        }
+    }
+    return false;
+}
+
+/** @type {{ ok: boolean, name: string, detail: string }[]} */
+const results = [];
+const record = (ok, checkName, detail) => results.push({ ok, name: checkName, detail });
+
+// 1. Version resolves on the registry.
+async function checkVersionLive() {
+    let detail = '';
+    const ok = await withRetry('version-live', () => {
+        const view = npm(['view', `${name}@${version}`, 'version']);
+        const out = (view.stdout ?? '').trim();
+        detail = out || (view.stderr ?? '').trim();
+        return view.status === 0 && out === version;
+    });
+    record(
+        ok,
+        'version-live',
+        ok ? `${name}@${version} is live on npm.` : `${name}@${version} did not resolve after ${MAX_ATTEMPTS} attempts (last: ${detail}).`,
+    );
+}
+
+// 2. `latest` dist-tag points at this version.
+async function checkLatestDistTag() {
+    let detail = '';
+    const ok = await withRetry('dist-tag-latest', () => {
+        const view = npm(['view', name, 'dist-tags.latest']);
+        detail = (view.stdout ?? '').trim();
+        return view.status === 0 && detail === version;
+    });
+    record(
+        ok,
+        'dist-tag-latest',
+        ok ? `dist-tag "latest" → ${version}.` : `dist-tag "latest" is "${detail}", expected ${version} (after retries).`,
+    );
+}
+
+// 3. Provenance attestation present.
+async function checkProvenance() {
+    let detail = '';
+    const ok = await withRetry('provenance', () => {
+        const view = npm(['view', `${name}@${version}`, '--json']);
+        if (view.status !== 0) {
+            detail = (view.stderr ?? '').trim();
+            return false;
+        }
+        try {
+            const parsed = JSON.parse(view.stdout);
+            const meta = Array.isArray(parsed) ? parsed[0] : parsed;
+            const attestations = meta?.dist?.attestations;
+            if (attestations && (attestations.url || attestations.provenance)) {
+                detail = attestations.provenance?.predicateType ?? attestations.url;
+                return true;
+            }
+            detail = 'no dist.attestations field';
+            return false;
+        } catch {
+            detail = 'could not parse npm view --json';
+            return false;
+        }
+    });
+    record(ok, 'provenance', ok ? `Provenance attestation present (${detail}).` : `No provenance attestation after retries (${detail}).`);
+}
+
+// 4. Install + import smoke test against the published artifact.
+async function checkInstallSmoke() {
+    const dir = mkdtempSync(path.join(tmpdir(), 'pvc-smoke-'));
+    try {
+        writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'pvc-smoke', version: '0.0.0', private: true }));
+        const installed = await withRetry('install', () => {
+            const install = npm(['install', '--no-audit', '--no-fund', `${name}@${version}`], { cwd: dir });
+            return install.status === 0;
+        });
+        if (!installed) {
+            record(false, 'install-smoke', `Could not install ${name}@${version} into a temp project after ${MAX_ATTEMPTS} attempts.`);
+            return;
+        }
+        const smokeSource = [
+            `import(${JSON.stringify(name)}).then((mod) => {`,
+            `  const compare = mod.comparePng ?? mod.default?.comparePng;`,
+            `  const compareAsync = mod.comparePngAsync ?? mod.default?.comparePngAsync;`,
+            `  if (typeof compare !== 'function' || typeof compareAsync !== 'function') {`,
+            `    console.error('public API missing: comparePng/comparePngAsync');`,
+            `    process.exit(2);`,
+            `  }`,
+            `  console.log('import ok');`,
+            `}).catch((error) => { console.error(error); process.exit(3); });`,
+        ].join('\n');
+        const smoke = spawnSync(process.execPath, ['--input-type=module', '-e', smokeSource], { cwd: dir, encoding: 'utf8' });
+        if (smoke.status === 0) {
+            record(true, 'install-smoke', `Installed ${name}@${version} imports and exposes comparePng/comparePngAsync.`);
+        } else {
+            record(false, 'install-smoke', `Imported package failed smoke test (exit ${smoke.status}): ${(smoke.stderr ?? '').trim()}`);
+        }
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+await checkVersionLive();
+await checkLatestDistTag();
+await checkProvenance();
+await checkInstallSmoke();
+
+for (const result of results) {
+    const symbol = result.ok ? '✓' : '✗';
+    const stream = result.ok ? process.stdout : process.stderr;
+    stream.write(`${symbol} ${result.name}: ${result.detail}\n`);
+}
+
+const failures = results.filter((result) => !result.ok);
+if (failures.length > 0) {
+    process.stderr.write(`\nPost-release check FAILED: ${failures.length} of ${results.length} checks did not pass.\n`);
+    process.exit(1);
+}
+
+process.stdout.write(`\nPost-release check passed: all ${results.length} checks OK for ${name}@${version}.\n`);

--- a/scripts/prerelease-check.mjs
+++ b/scripts/prerelease-check.mjs
@@ -1,0 +1,172 @@
+/**
+ * Pre-release verification gate for png-visual-compare.
+ *
+ * Asserts the repository is in a publishable state BEFORE `npm publish` runs:
+ *   1. the version in package.json is not already published on npm,
+ *   2. CHANGELOG.md has a section for the version (not just [Unreleased]),
+ *   3. CODEMAP.md is stamped with the same version,
+ *   4. package-lock.json agrees on the version,
+ *   5. the package tarball would ship only `./out`,
+ *   6. (CI only) the release tag matches the version.
+ *
+ * Exits non-zero on the first set of failures so a release can never ship with
+ * drifted metadata. Run locally with `npm run release:check:pre` (build first so
+ * the pack-contents check sees `./out`). Wired as the gate before `npm publish`
+ * in `.github/workflows/publish.yml`, which sets `RELEASE_TAG` from the GitHub
+ * Release tag to enable check 6.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readJson(relativePath) {
+    return JSON.parse(readFileSync(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+const pkg = readJson('package.json');
+const { name, version } = pkg;
+
+/** @type {{ ok: boolean, name: string, detail: string }[]} */
+const results = [];
+
+function record(ok, checkName, detail) {
+    results.push({ ok, name: checkName, detail });
+}
+
+function npm(args) {
+    return spawnSync('npm', args, { encoding: 'utf8' });
+}
+
+// 1. Version must not already be published on npm.
+function checkVersionNotPublished() {
+    const view = npm(['view', `${name}@${version}`, 'version']);
+    const stdout = (view.stdout ?? '').trim();
+    const stderr = view.stderr ?? '';
+    if (view.status === 0 && stdout.length > 0) {
+        record(false, 'version-not-published', `${name}@${version} is already published on npm; bump the version before releasing.`);
+        return;
+    }
+    if (/E404|404 Not Found|No match found/.test(stderr)) {
+        record(true, 'version-not-published', `${name}@${version} is not yet on npm.`);
+        return;
+    }
+    record(
+        false,
+        'version-not-published',
+        `Could not verify npm publish status (npm view exited ${view.status}): ${stderr.trim() || 'unknown error'}`,
+    );
+}
+
+// 2. CHANGELOG has a section for this version.
+function checkChangelogSection() {
+    const changelog = readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
+    const heading = `## [${version}]`;
+    if (changelog.includes(heading)) {
+        record(true, 'changelog-section', `Found "${heading}" in CHANGELOG.md.`);
+    } else {
+        record(
+            false,
+            'changelog-section',
+            `CHANGELOG.md has no "${heading}" section; cut the [Unreleased] entries into a ${version} heading.`,
+        );
+    }
+}
+
+// 3. CODEMAP version stamp matches package.json.
+function checkCodemapVersion() {
+    const codemap = readFileSync(path.join(repoRoot, 'CODEMAP.md'), 'utf8');
+    const match = codemap.match(/"version":\s*"([^"]+)"/);
+    const stamped = match?.[1];
+    if (stamped === version) {
+        record(true, 'codemap-version', `CODEMAP.md is stamped ${version}.`);
+    } else {
+        record(false, 'codemap-version', `CODEMAP.md version is ${stamped ?? '(missing)'}, expected ${version}; run \`npm run codemap\`.`);
+    }
+}
+
+// 4. Lockfile version matches package.json.
+function checkLockfileVersion() {
+    const lock = readJson('package-lock.json');
+    const rootVersion = lock.version;
+    const selfEntryVersion = lock.packages?.['']?.version;
+    if (rootVersion === version && (selfEntryVersion === undefined || selfEntryVersion === version)) {
+        record(true, 'lockfile-version', `package-lock.json is at ${version}.`);
+    } else {
+        record(
+            false,
+            'lockfile-version',
+            `package-lock.json version is ${rootVersion}/${selfEntryVersion}, expected ${version}; run \`npm install\`.`,
+        );
+    }
+}
+
+// 5. npm pack ships only ./out plus the files npm always includes.
+// package.json, README*, and LICENSE/LICENCE* are bundled by npm regardless of
+// the "files" field, so they are allowed at the tarball root; everything else
+// must live under out/.
+const ALWAYS_INCLUDED = /^(package\.json|readme(\.[^/]+)?|licen[sc]e(\.[^/]+)?)$/i;
+
+function checkPackContents() {
+    const pack = npm(['pack', '--dry-run', '--json']);
+    if (pack.status !== 0) {
+        record(false, 'pack-contents', `\`npm pack --dry-run\` failed (exit ${pack.status}): ${(pack.stderr ?? '').trim()}`);
+        return;
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(pack.stdout);
+    } catch {
+        record(false, 'pack-contents', 'Could not parse `npm pack --dry-run --json` output.');
+        return;
+    }
+    const files = (Array.isArray(parsed) ? parsed[0]?.files : undefined) ?? [];
+    if (files.length === 0) {
+        record(false, 'pack-contents', 'Package tarball would be empty; run `npm run build` before releasing.');
+        return;
+    }
+    const stray = files.map((file) => file.path).filter((filePath) => !filePath.startsWith('out/') && !ALWAYS_INCLUDED.test(filePath));
+    if (stray.length > 0) {
+        record(false, 'pack-contents', `Tarball would include unexpected files: ${stray.join(', ')}`);
+    } else {
+        record(true, 'pack-contents', `Tarball ships ${files.length} files (out/ + npm metadata only).`);
+    }
+}
+
+// 6. In CI, the release tag must match the version.
+function checkReleaseTag() {
+    const tag = process.env.RELEASE_TAG;
+    if (!tag) {
+        record(true, 'release-tag', 'RELEASE_TAG not set (local run); skipping tag/version match.');
+        return;
+    }
+    const expected = `release/v${version}`;
+    if (tag === expected) {
+        record(true, 'release-tag', `Release tag ${tag} matches version.`);
+    } else {
+        record(false, 'release-tag', `Release tag is "${tag}", expected "${expected}".`);
+    }
+}
+
+checkVersionNotPublished();
+checkChangelogSection();
+checkCodemapVersion();
+checkLockfileVersion();
+checkPackContents();
+checkReleaseTag();
+
+for (const result of results) {
+    const symbol = result.ok ? '✓' : '✗';
+    const stream = result.ok ? process.stdout : process.stderr;
+    stream.write(`${symbol} ${result.name}: ${result.detail}\n`);
+}
+
+const failures = results.filter((result) => !result.ok);
+if (failures.length > 0) {
+    process.stderr.write(`\nPre-release check FAILED: ${failures.length} of ${results.length} checks did not pass.\n`);
+    process.exit(1);
+}
+
+process.stdout.write(`\nPre-release check passed: all ${results.length} checks OK for ${name}@${version}.\n`);


### PR DESCRIPTION
## Summary

Prepares the **6.2.0** release and modernizes publishing to **npm Trusted Publishing (OIDC)**, removing the long-lived `NPM_TOKEN` from CI. Adds pre/post-release verification scripts that guard against the exact drift that stranded earlier releases (6.2.0 was bumped but never published — npm latest is still 6.1.0).

## Changes

### OIDC Trusted Publishing (`publish.yml`)
- Drops `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — auth is now via GitHub OIDC. Provenance is generated automatically; `--provenance` retained.
- Adds `npm install -g npm@latest` (Trusted Publishing requires npm ≥ 11.5.1; `.nvmrc` is Node 24).
- Keeps `permissions: id-token: write`, no GitHub Environment (repo + workflow binding only).

### Release check scripts (`scripts/`, npm scripts + CI steps)
- **`release:check:pre`** (runs locally + before `npm publish`): version not already on npm · CHANGELOG has the version section · CODEMAP version stamp matches · lockfile version matches · tarball ships only `./out` (+ npm metadata) · release tag matches version (CI).
- **`release:check:post`** (runs after `npm publish` + locally): version resolves on npm · `latest` dist-tag points at it · provenance attestation present · install + `import()` smoke test of the published artifact (retries to absorb CDN propagation).

### Release notes (`CHANGELOG.md`)
- Folds `[Unreleased]` (checkerboard, RELI-06, RELI-07, builder fix) into the **6.2.0** section, re-dated `2026-06-19`.
- SemVer: MINOR. Two additive features (`checkerboard`, `ComparisonError`); RELI-06 (negative `excludedAreas` coords now throw instead of silent clamp-to-0) is validation tightening of undocumented input, not a public-API break.

## ⚠️ Required before merge/release

npm Trusted Publishing must be configured **on npmjs.com** (Package → Settings → Trusted Publishing), or the OIDC publish fails auth:
- Publisher: **GitHub Actions**
- Organization/user: **dichovsky**
- Repository: **png-visual-compare**
- Workflow filename: **publish.yml**
- Environment: **(none)**

## Verification

| Gate | Result |
|------|--------|
| `npm run release:check:pre` (local, post-build) | ✅ all 6 checks pass |
| `npm run test:unit` (lint/format/typecheck/license/codemap + coverage) | ✅ 406 tests, 100% coverage |
| `release:check:post` smoke logic vs. live 6.1.0 | ✅ `import()` resolves `comparePng`/`comparePngAsync` on Node 24 |
| provenance field shape | ✅ verified against a provenanced package (`dist.attestations.provenance.predicateType`) |

## Release flow after merge
1. Configure npmjs.com trusted publisher (above).
2. Merge this PR to `main`.
3. Create GitHub Release with tag `release/v6.2.0` (non-prerelease) → `publish.yml` runs pre-check → OIDC publish → post-check.

## Notes / follow-ups
- `CHANGELOG.md` has a `[6.1.1]` section that was never published (npm jumped 6.0.0 → 6.1.0). Pre-existing history quirk, left untouched.
- Release scripts are npm/CLI glue (like the untested `check-licenses.mjs`) and are outside the `src/**` coverage scope; validated by execution rather than unit tests.
