### PR TITLE
chore: release 6.3.0 — support .not.toMatchPngSnapshot()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.0] - 2026-07-29
+
+### Added
+
+- **`.not.toMatchPngSnapshot()`** — negated snapshot assertions are now
+  supported in both the Vitest and Jest matchers, and assert that the received
+  PNG **differs** from the stored snapshot. Previously any `.not` usage threw
+  `.not.toMatchPngSnapshot() is not supported.`
+    - Passes when the received PNG differs beyond the configured threshold;
+      fails when it matches.
+    - **Never writes or updates a snapshot**, even under `-u` — you cannot
+      record what an image must _not_ be.
+    - **Throws when no snapshot is stored**, rather than passing vacuously on a
+      missing baseline.
+    - Invalid input (non-PNG value, malformed matcher arguments) now throws
+      under `.not` instead of reporting `pass: false`, which the test framework
+      would have inverted into a silently passing assertion.
+
+### Changed
+
+- **TypeScript 7** — `build` and `typecheck` now run the native TypeScript 7
+  compiler via the `@typescript/native` alias. TypeScript 6 is retained under
+  the `typescript` alias because the codemap generator, its tests, and
+  `typescript-eslint` still require the legacy compiler API. This is a
+  development-only change: the published `out/` artifact is semantically
+  identical, differing from a TypeScript 6 build only in `.d.ts` quote style and
+  one union member ordering. See `docs/TYPESCRIPT_7_MIGRATION.md`.
+- Refreshed development dependencies (`@playwright/test`, `@types/node`,
+  `@vitest/coverage-v8`, `eslint`, `prettier`, `typescript-eslint`, `vitest`)
+  and pinned GitHub Actions digests.
+
 ## [6.2.0] - 2026-06-19
 
 ### Added

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -12,7 +12,7 @@ Schema: `codemap.v2`
     "schema": "codemap.v2",
     "repo": {
         "name": "png-visual-compare",
-        "version": "6.2.0"
+        "version": "6.3.0"
     },
     "sourceHash": "e394b94734da831c89abaa111bcc2e057eee46bfa24f0cec44e192dfc1abae5b",
     "entrypoints": [

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -14,7 +14,7 @@ Schema: `codemap.v2`
         "name": "png-visual-compare",
         "version": "6.2.0"
     },
-    "sourceHash": "77a978c030f2c233761bf39cfad6731ebb5332e9d75948d6398f29e6461ea2a2",
+    "sourceHash": "e394b94734da831c89abaa111bcc2e057eee46bfa24f0cec44e192dfc1abae5b",
     "entrypoints": [
         "src/index.ts",
         "src/jest.ts",
@@ -186,7 +186,7 @@ Schema: `codemap.v2`
             "kind": "function",
             "entrypoint": "src/jest.ts",
             "file": "src/jest.ts",
-            "line": 180,
+            "line": 218,
             "signature": "export function registerJestPngSnapshotMatcher(expect: ExpectLike): void",
             "jsdoc": null,
             "typeOnly": false
@@ -646,7 +646,7 @@ Schema: `codemap.v2`
                 {
                     "name": "JEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "kind": "const",
-                    "line": 8,
+                    "line": 13,
                     "exported": false,
                     "signature": "const JEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "members": null,
@@ -655,7 +655,7 @@ Schema: `codemap.v2`
                 {
                     "name": "ExpectLike",
                     "kind": "type",
-                    "line": 10,
+                    "line": 15,
                     "exported": false,
                     "signature": "type ExpectLike = { extend: (matchers: Record<string, unknown>) => void; };",
                     "members": null,
@@ -664,7 +664,7 @@ Schema: `codemap.v2`
                 {
                     "name": "SnapshotStateLike",
                     "kind": "type",
-                    "line": 14,
+                    "line": 19,
                     "exported": false,
                     "signature": "type SnapshotStateLike = { added?: number; expand?: boolean; matched?: number; unmatched?: number; updated?: number; markSnapshotsAsCheckedForTest?: (testName: string) => void; [key: string]: unknown;…",
                     "members": null,
@@ -673,16 +673,16 @@ Schema: `codemap.v2`
                 {
                     "name": "JestMatcherContext",
                     "kind": "type",
-                    "line": 24,
+                    "line": 29,
                     "exported": false,
-                    "signature": "type JestMatcherContext = { currentConcurrentTestName?: () => string | undefined; currentTestName?: string; error?: Error; snapshotState?: SnapshotStateLike | null; testFailing?: boolean; };",
+                    "signature": "type JestMatcherContext = { currentConcurrentTestName?: () => string | undefined; currentTestName?: string; error?: Error; isNot?: boolean; snapshotState?: SnapshotStateLike | null; testFailing?: bool…",
                     "members": null,
                     "jsdoc": null
                 },
                 {
                     "name": "addOuterLineBreaks",
                     "kind": "function",
-                    "line": 32,
+                    "line": 38,
                     "exported": false,
                     "signature": "function addOuterLineBreaks(value: string): string",
                     "members": null,
@@ -691,7 +691,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getSnapshotData",
                     "kind": "function",
-                    "line": 36,
+                    "line": 42,
                     "exported": false,
                     "signature": "function getSnapshotData(snapshotState: SnapshotStateLike): Record<string, string>",
                     "members": null,
@@ -700,7 +700,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getSnapshotCounters",
                     "kind": "function",
-                    "line": 46,
+                    "line": 52,
                     "exported": false,
                     "signature": "function getSnapshotCounters(snapshotState: SnapshotStateLike): Map<string, number>",
                     "members": null,
@@ -709,7 +709,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getUncheckedKeys",
                     "kind": "function",
-                    "line": 56,
+                    "line": 62,
                     "exported": false,
                     "signature": "function getUncheckedKeys(snapshotState: SnapshotStateLike): Set<string>",
                     "members": null,
@@ -718,7 +718,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getUpdateSnapshotMode",
                     "kind": "function",
-                    "line": 66,
+                    "line": 72,
                     "exported": false,
                     "signature": "function getUpdateSnapshotMode(snapshotState: SnapshotStateLike): 'all' | 'new' | 'none'",
                     "members": null,
@@ -727,7 +727,7 @@ Schema: `codemap.v2`
                 {
                     "name": "setSnapshotDirty",
                     "kind": "function",
-                    "line": 76,
+                    "line": 82,
                     "exported": false,
                     "signature": "function setSnapshotDirty(snapshotState: SnapshotStateLike): void",
                     "members": null,
@@ -736,7 +736,7 @@ Schema: `codemap.v2`
                 {
                     "name": "incrementSnapshotCounter",
                     "kind": "function",
-                    "line": 80,
+                    "line": 86,
                     "exported": false,
                     "signature": "function incrementSnapshotCounter(snapshotState: SnapshotStateLike, field: 'added' | 'matched' | 'unmatched' | 'updated'): void",
                     "members": null,
@@ -745,7 +745,7 @@ Schema: `codemap.v2`
                 {
                     "name": "resolveSnapshotKey",
                     "kind": "function",
-                    "line": 85,
+                    "line": 91,
                     "exported": false,
                     "signature": "function resolveSnapshotKey(snapshotState: SnapshotStateLike, testName: string): { count: number; key: string }",
                     "members": null,
@@ -754,16 +754,25 @@ Schema: `codemap.v2`
                 {
                     "name": "createJestMismatchMessage",
                     "kind": "function",
-                    "line": 95,
+                    "line": 101,
                     "exported": false,
                     "signature": "function createJestMismatchMessage(testName: string, mismatchedPixels: number): string",
                     "members": null,
                     "jsdoc": null
                 },
                 {
+                    "name": "createJestNegatedMatchMessage",
+                    "kind": "function",
+                    "line": 108,
+                    "exported": false,
+                    "signature": "function createJestNegatedMatchMessage(testName: string): string",
+                    "members": null,
+                    "jsdoc": null
+                },
+                {
                     "name": "createJestMissingSnapshotMessage",
                     "kind": "function",
-                    "line": 102,
+                    "line": 114,
                     "exported": false,
                     "signature": "function createJestMissingSnapshotMessage(testName: string): string",
                     "members": null,
@@ -772,7 +781,7 @@ Schema: `codemap.v2`
                 {
                     "name": "persistJestSnapshot",
                     "kind": "function",
-                    "line": 108,
+                    "line": 120,
                     "exported": false,
                     "signature": "function persistJestSnapshot(snapshotState: SnapshotStateLike, key: string, serializedSnapshot: string): void",
                     "members": null,
@@ -781,7 +790,7 @@ Schema: `codemap.v2`
                 {
                     "name": "toMatchPngSnapshot",
                     "kind": "const",
-                    "line": 113,
+                    "line": 125,
                     "exported": false,
                     "signature": "const toMatchPngSnapshot",
                     "members": null,
@@ -790,7 +799,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getGlobalExpect",
                     "kind": "function",
-                    "line": 176,
+                    "line": 214,
                     "exported": false,
                     "signature": "function getGlobalExpect(): ExpectLike | undefined",
                     "members": null,
@@ -799,7 +808,7 @@ Schema: `codemap.v2`
                 {
                     "name": "registerJestPngSnapshotMatcher",
                     "kind": "function",
-                    "line": 180,
+                    "line": 218,
                     "exported": true,
                     "signature": "export function registerJestPngSnapshotMatcher(expect: ExpectLike): void",
                     "members": null,
@@ -808,7 +817,7 @@ Schema: `codemap.v2`
                 {
                     "name": "jestExpect",
                     "kind": "const",
-                    "line": 187,
+                    "line": 225,
                     "exported": false,
                     "signature": "const jestExpect",
                     "members": null,
@@ -944,9 +953,18 @@ Schema: `codemap.v2`
                     "jsdoc": null
                 },
                 {
+                    "name": "NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE",
+                    "kind": "const",
+                    "line": 30,
+                    "exported": true,
+                    "signature": "export const NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE = '.not.toMatchPngSnapshot() requires an existing snapshot to compare against.'",
+                    "members": null,
+                    "jsdoc": "Thrown by `.not.toMatchPngSnapshot()` when there is no stored snapshot to compare against. A missing baseline must never pass vacuously — you cannot record what an image must *not* be."
+                },
+                {
                     "name": "ComparedPngSnapshot",
                     "kind": "type",
-                    "line": 25,
+                    "line": 32,
                     "exported": true,
                     "signature": "export type ComparedPngSnapshot = { pass: boolean; mismatchedPixels: number; actualSerialized: string; expectedSerialized: string; };",
                     "members": null,
@@ -955,7 +973,7 @@ Schema: `codemap.v2`
                 {
                     "name": "hasPngSignature",
                     "kind": "function",
-                    "line": 32,
+                    "line": 39,
                     "exported": false,
                     "signature": "function hasPngSignature(value: Uint8Array): boolean",
                     "members": null,
@@ -964,7 +982,7 @@ Schema: `codemap.v2`
                 {
                     "name": "isComparePngOptions",
                     "kind": "function",
-                    "line": 46,
+                    "line": 53,
                     "exported": false,
                     "signature": "function isComparePngOptions(value: unknown): value is ComparePngOptions",
                     "members": null,
@@ -973,7 +991,7 @@ Schema: `codemap.v2`
                 {
                     "name": "isSerializedPngSnapshot",
                     "kind": "function",
-                    "line": 50,
+                    "line": 57,
                     "exported": false,
                     "signature": "function isSerializedPngSnapshot(value: unknown): value is SerializedPngSnapshot",
                     "members": null,
@@ -982,7 +1000,7 @@ Schema: `codemap.v2`
                 {
                     "name": "normalizePngSnapshotMatcherArgs",
                     "kind": "function",
-                    "line": 60,
+                    "line": 67,
                     "exported": true,
                     "signature": "export function normalizePngSnapshotMatcherArgs( hintOrOptions?: string | ComparePngOptions, options?: ComparePngOptions, ): NormalizedMatcherArgsResult",
                     "members": null,
@@ -991,7 +1009,7 @@ Schema: `codemap.v2`
                 {
                     "name": "buildSnapshotTestName",
                     "kind": "function",
-                    "line": 98,
+                    "line": 105,
                     "exported": true,
                     "signature": "export function buildSnapshotTestName(testName: string | undefined, hint: string | undefined, separator: string): string",
                     "members": null,
@@ -1000,7 +1018,7 @@ Schema: `codemap.v2`
                 {
                     "name": "serializePngSnapshot",
                     "kind": "function",
-                    "line": 102,
+                    "line": 109,
                     "exported": true,
                     "signature": "export function serializePngSnapshot(received: Buffer): string",
                     "members": null,
@@ -1009,7 +1027,7 @@ Schema: `codemap.v2`
                 {
                     "name": "parseSerializedPngSnapshot",
                     "kind": "function",
-                    "line": 106,
+                    "line": 113,
                     "exported": true,
                     "signature": "export function parseSerializedPngSnapshot(serializedSnapshot: string): Buffer",
                     "members": null,
@@ -1018,7 +1036,7 @@ Schema: `codemap.v2`
                 {
                     "name": "compareAgainstSerializedPngSnapshot",
                     "kind": "function",
-                    "line": 128,
+                    "line": 135,
                     "exported": true,
                     "signature": "export function compareAgainstSerializedPngSnapshot( received: Buffer, serializedExpectedSnapshot: string, options?: ComparePngOptions, ): ComparedPngSnapshot",
                     "members": null,
@@ -1800,7 +1818,7 @@ Schema: `codemap.v2`
                 {
                     "name": "VITEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "kind": "const",
-                    "line": 23,
+                    "line": 28,
                     "exported": false,
                     "signature": "const VITEST_PNG_SNAPSHOT_MATCHER_KEY",
                     "members": null,
@@ -1809,7 +1827,7 @@ Schema: `codemap.v2`
                 {
                     "name": "VitestTestLike",
                     "kind": "type",
-                    "line": 25,
+                    "line": 30,
                     "exported": false,
                     "signature": "type VitestTestLike = { id: string; };",
                     "members": null,
@@ -1818,7 +1836,7 @@ Schema: `codemap.v2`
                 {
                     "name": "VitestExpectedSnapshot",
                     "kind": "type",
-                    "line": 29,
+                    "line": 34,
                     "exported": false,
                     "signature": "type VitestExpectedSnapshot = { count: number; data?: string; key: string; markAsChecked: () => void; };",
                     "members": null,
@@ -1827,7 +1845,7 @@ Schema: `codemap.v2`
                 {
                     "name": "VitestSnapshotReturn",
                     "kind": "type",
-                    "line": 36,
+                    "line": 41,
                     "exported": false,
                     "signature": "type VitestSnapshotReturn = { actual: string; expected?: string; key: string; pass: boolean; };",
                     "members": null,
@@ -1836,7 +1854,7 @@ Schema: `codemap.v2`
                 {
                     "name": "VitestSnapshotState",
                     "kind": "type",
-                    "line": 43,
+                    "line": 48,
                     "exported": false,
                     "signature": "type VitestSnapshotState = { probeExpectedSnapshot: (options: { inlineSnapshot?: string; isInline: boolean; testId: string; testName: string; }) => VitestExpectedSnapshot; processDomainSnapshot: (opti…",
                     "members": null,
@@ -1845,7 +1863,7 @@ Schema: `codemap.v2`
                 {
                     "name": "MatcherStateWithSnapshot",
                     "kind": "type",
-                    "line": 65,
+                    "line": 70,
                     "exported": false,
                     "signature": "type MatcherStateWithSnapshot = MatcherState & { error?: Error; snapshotState?: VitestSnapshotState | null; };",
                     "members": null,
@@ -1854,7 +1872,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getVitestTest",
                     "kind": "function",
-                    "line": 70,
+                    "line": 75,
                     "exported": false,
                     "signature": "function getVitestTest(matcherContext: MatcherState): VitestTestLike",
                     "members": null,
@@ -1863,7 +1881,7 @@ Schema: `codemap.v2`
                 {
                     "name": "getAssertionName",
                     "kind": "function",
-                    "line": 80,
+                    "line": 85,
                     "exported": false,
                     "signature": "function getAssertionName(matcherContext: MatcherState): string",
                     "members": null,
@@ -1872,7 +1890,7 @@ Schema: `codemap.v2`
                 {
                     "name": "toMatchPngSnapshot",
                     "kind": "const",
-                    "line": 90,
+                    "line": 95,
                     "exported": false,
                     "signature": "const toMatchPngSnapshot",
                     "members": null,

--- a/README.md
+++ b/README.md
@@ -195,7 +195,20 @@ import { registerJestPngSnapshotMatcher } from 'png-visual-compare/jest';
 registerJestPngSnapshotMatcher(expect);
 ```
 
-`toMatchPngSnapshot()` is intentionally strict: it accepts only PNG `Buffer` / `Uint8Array` input, does not support `.not`, and passes any provided `ComparePngOptions` to `comparePng` when checking the stored snapshot.
+`toMatchPngSnapshot()` is intentionally strict: it accepts only PNG `Buffer` / `Uint8Array` input, and passes any provided `ComparePngOptions` to `comparePng` when checking the stored snapshot.
+
+### Negated assertions
+
+`expect(received).not.toMatchPngSnapshot()` asserts that the received PNG **differs** from the stored snapshot:
+
+```typescript
+expect(await page.screenshot()).not.toMatchPngSnapshot('light mode');
+```
+
+- **Passes** when the received PNG differs from the stored snapshot beyond the configured threshold.
+- **Fails** when they match.
+- **Never writes or updates a snapshot**, even under `-u` — you cannot record what an image must _not_ be.
+- **Throws when no snapshot is stored.** A missing baseline would otherwise pass vacuously, which is a false green. Record the baseline with a positive `toMatchPngSnapshot()` first.
 
 ---
 

--- a/__tests__/pngSnapshotMatcher.test.ts
+++ b/__tests__/pngSnapshotMatcher.test.ts
@@ -113,10 +113,35 @@ describe('createPngSnapshotMatcher', () => {
         expect(snapshotDelegate).toHaveBeenCalledWith({}, expect.any(Buffer), { hint: undefined, options });
     });
 
-    test('rejects .not because snapshot negation is unsupported', () => {
+    test('forwards the negated matcher context to the delegate', () => {
+        const snapshotDelegate = vi.fn<(...args: [unknown, Buffer, PngSnapshotMatcherArgs]) => { pass: false; message: () => string }>(
+            () => ({
+                pass: false,
+                message: () => '',
+            }),
+        );
+        const matcher = createPngSnapshotMatcher(snapshotDelegate);
+
+        const result = expectSyncResult(matcher.call({ isNot: true }, readFileSync(PNG_FILE)));
+
+        expect(snapshotDelegate).toHaveBeenCalledWith({ isNot: true }, expect.any(Buffer), { hint: undefined, options: undefined });
+        expect(result.pass).toBe(false);
+    });
+
+    test('throws on non-PNG input under .not instead of passing vacuously', () => {
         const matcher = createPngSnapshotMatcher(() => ({ pass: true, message: () => '' }));
 
-        expect(() => matcher.call({ isNot: true }, readFileSync(PNG_FILE))).toThrow('.not.toMatchPngSnapshot() is not supported.');
+        expect(() => matcher.call({ isNot: true }, 'not a png')).toThrow(
+            'toMatchPngSnapshot() expects a PNG Buffer or Uint8Array, but received string.',
+        );
+    });
+
+    test('throws on invalid matcher arguments under .not instead of passing vacuously', () => {
+        const matcher = createPngSnapshotMatcher(() => ({ pass: true, message: () => '' }));
+
+        expect(() => matcher.call({ isNot: true }, readFileSync(PNG_FILE), 42 as never)).toThrow(
+            'toMatchPngSnapshot() expects either a snapshot hint string or a ComparePngOptions object as the first argument.',
+        );
     });
 
     test.each([
@@ -277,13 +302,103 @@ describe('vitest matcher entrypoint', () => {
         expect(extendSpy).not.toHaveBeenCalled();
     });
 
-    test('rejects a real expect().not.toMatchPngSnapshot() assertion driven through Vitest', async () => {
+    test('throws on a real expect().not.toMatchPngSnapshot() assertion with no stored snapshot', async () => {
         vi.resetModules();
         clearMatcherRegistration();
 
         await import('../src/vitest.mjs');
 
-        expect(() => expect(readFileSync(PNG_FILE)).not.toMatchPngSnapshot()).toThrow('.not.toMatchPngSnapshot() is not supported.');
+        expect(() => expect(readFileSync(PNG_FILE)).not.toMatchPngSnapshot()).toThrow(
+            '.not.toMatchPngSnapshot() requires an existing snapshot to compare against.',
+        );
+    });
+
+    test('passes a negated Vitest assertion when the received PNG differs from the stored snapshot', async () => {
+        vi.resetModules();
+        clearMatcherRegistration();
+        const extendSpy = vi.spyOn(expect, 'extend');
+
+        await import('../src/vitest.mjs');
+
+        const registeredMatchers = extendSpy.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Vitest matcher to be registered');
+        }
+
+        const assertion = {};
+        chai.util.flag(assertion, 'vitest-test', { id: 'vitest-negated-differs-id' });
+        chai.util.flag(assertion, '_name', 'toMatchPngSnapshot');
+        const markAsChecked = vi.fn();
+        const processDomainSnapshot = vi.fn();
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call(
+                {
+                    assertion,
+                    isNot: true,
+                    currentTestName: 'differs from snapshot',
+                    snapshotState: {
+                        probeExpectedSnapshot: () => ({
+                            count: 1,
+                            data: serializePngSnapshot(createSolidPng(255, 0, 0)),
+                            key: 'differs from snapshot 1',
+                            markAsChecked,
+                        }),
+                        processDomainSnapshot,
+                    },
+                } as never,
+                createSolidPng(0, 0, 255),
+            ),
+        );
+
+        // pass: false is what the framework inverts into a passing `.not`.
+        expect(result.pass).toBe(false);
+        expect(markAsChecked).toHaveBeenCalledTimes(1);
+        expect(processDomainSnapshot).not.toHaveBeenCalled();
+    });
+
+    test('fails a negated Vitest assertion when the received PNG matches the stored snapshot', async () => {
+        vi.resetModules();
+        clearMatcherRegistration();
+        const extendSpy = vi.spyOn(expect, 'extend');
+
+        await import('../src/vitest.mjs');
+
+        const registeredMatchers = extendSpy.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Vitest matcher to be registered');
+        }
+
+        const assertion = {};
+        chai.util.flag(assertion, 'vitest-test', { id: 'vitest-negated-matches-id' });
+        chai.util.flag(assertion, '_name', 'toMatchPngSnapshot');
+        const processDomainSnapshot = vi.fn();
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call(
+                {
+                    assertion,
+                    isNot: true,
+                    currentTestName: 'matches snapshot',
+                    snapshotState: {
+                        probeExpectedSnapshot: () => ({
+                            count: 1,
+                            data: serializePngSnapshot(readFileSync(PNG_FILE)),
+                            key: 'matches snapshot 1',
+                            markAsChecked: vi.fn(),
+                        }),
+                        processDomainSnapshot,
+                    },
+                } as never,
+                readFileSync(PNG_FILE),
+            ),
+        );
+
+        expect(result.pass).toBe(true);
+        expect(result.message()).toBe('Snapshot `matches snapshot 1` matched but was expected to differ');
+        expect(result.actual).toContain('"type": "Buffer"');
+        expect(result.expected).toContain('"type": "Buffer"');
+        expect(processDomainSnapshot).not.toHaveBeenCalled();
     });
 
     test('compares stored Vitest PNG snapshots with ComparePngOptions', async () => {
@@ -1003,5 +1118,120 @@ describe('jest matcher entrypoint', () => {
         const jestPlugin = (await import('../src/jest.js')) as JestPluginModule;
 
         expect(jestPlugin.registerJestPngSnapshotMatcher).toBeTypeOf('function');
+    });
+
+    test('throws on a negated Jest assertion when no snapshot is stored', async () => {
+        vi.resetModules();
+        const extend = vi.fn();
+        (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
+
+        await import('../src/jest.js');
+
+        const registeredMatchers = extend.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Jest matcher to be registered');
+        }
+
+        const snapshotState = createJestSnapshotState({}, 'all');
+
+        expect(() =>
+            registeredMatchers.toMatchPngSnapshot.call(
+                { currentTestName: 'missing baseline', isNot: true, snapshotState } as never,
+                readFileSync(PNG_FILE),
+            ),
+        ).toThrow('.not.toMatchPngSnapshot() requires an existing snapshot to compare against.');
+
+        // Even under -u a negated assertion must never record a baseline.
+        expect(snapshotState._dirty).toBe(false);
+        expect(snapshotState.added).toBe(0);
+    });
+
+    test('passes a negated Jest assertion when the received PNG differs from the stored snapshot', async () => {
+        vi.resetModules();
+        const extend = vi.fn();
+        (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
+
+        await import('../src/jest.js');
+
+        const registeredMatchers = extend.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Jest matcher to be registered');
+        }
+
+        const storedSnapshot = serializePngSnapshot(createSolidPng(255, 0, 0));
+        const snapshotState = createJestSnapshotState({ 'differs from snapshot 1': storedSnapshot }, 'all');
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call(
+                { currentTestName: 'differs from snapshot', isNot: true, snapshotState } as never,
+                createSolidPng(0, 0, 255),
+            ),
+        );
+
+        // pass: false is what the framework inverts into a passing `.not`.
+        expect(result.pass).toBe(false);
+        expect(result.message()).toBe('');
+        expect(snapshotState.added).toBe(0);
+        expect(snapshotState.matched).toBe(0);
+        expect(snapshotState.unmatched).toBe(0);
+        expect(snapshotState.updated).toBe(0);
+        expect(snapshotState._dirty).toBe(false);
+        expect(snapshotState._snapshotData['differs from snapshot 1']).toBe(storedSnapshot);
+    });
+
+    test('fails a negated Jest assertion when the received PNG matches the stored snapshot', async () => {
+        vi.resetModules();
+        const extend = vi.fn();
+        (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
+
+        await import('../src/jest.js');
+
+        const registeredMatchers = extend.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Jest matcher to be registered');
+        }
+
+        const snapshotState = createJestSnapshotState({
+            'matches snapshot: dark mode 1': serializePngSnapshot(readFileSync(PNG_FILE)),
+        });
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call(
+                { currentTestName: 'matches snapshot', isNot: true, snapshotState } as never,
+                readFileSync(PNG_FILE),
+                'dark mode',
+            ),
+        );
+
+        expect(result.pass).toBe(true);
+        expect(result.message()).toBe(
+            'Received PNG snapshot matches the stored snapshot for "matches snapshot: dark mode", but was expected to differ.',
+        );
+        expect(snapshotState.unmatched).toBe(1);
+        expect(snapshotState.matched).toBe(0);
+        expect(snapshotState._dirty).toBe(false);
+    });
+
+    test('reports a negated Jest match without a test name', async () => {
+        vi.resetModules();
+        const extend = vi.fn();
+        (globalThis as typeof globalThis & { expect?: { extend: ExtendSpy } }).expect = { extend };
+
+        await import('../src/jest.js');
+
+        const registeredMatchers = extend.mock.calls[0]?.[0] as RegisteredMatchers | undefined;
+
+        if (registeredMatchers === undefined) {
+            throw new Error('Expected the Jest matcher to be registered');
+        }
+
+        const snapshotState = createJestSnapshotState({ ' 1': serializePngSnapshot(readFileSync(PNG_FILE)) });
+        const result = expectSyncResult(
+            registeredMatchers.toMatchPngSnapshot.call({ isNot: true, snapshotState } as never, readFileSync(PNG_FILE)),
+        );
+
+        expect(result.pass).toBe(true);
+        expect(result.message()).toBe('Received PNG snapshot matches the stored snapshot, but was expected to differ.');
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "png-visual-compare",
-    "version": "6.2.0",
+    "version": "6.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "png-visual-compare",
-            "version": "6.2.0",
+            "version": "6.3.0",
             "license": "MIT",
             "os": [
                 "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "png-visual-compare",
-    "version": "6.2.0",
+    "version": "6.3.0",
     "description": "Node.js utility to compare PNG files or their areas",
     "keywords": [
         "visual testing",

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -3,7 +3,12 @@
  */
 import type { ComparePngOptions } from './types';
 import { createPngSnapshotMatcher } from './matchers/createPngSnapshotMatcher';
-import { buildSnapshotTestName, compareAgainstSerializedPngSnapshot, serializePngSnapshot } from './matchers/pngSnapshot';
+import {
+    buildSnapshotTestName,
+    compareAgainstSerializedPngSnapshot,
+    NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE,
+    serializePngSnapshot,
+} from './matchers/pngSnapshot';
 
 const JEST_PNG_SNAPSHOT_MATCHER_KEY = Symbol.for('png-visual-compare/jest/toMatchPngSnapshot');
 
@@ -25,6 +30,7 @@ type JestMatcherContext = {
     currentConcurrentTestName?: () => string | undefined;
     currentTestName?: string;
     error?: Error;
+    isNot?: boolean;
     snapshotState?: SnapshotStateLike | null;
     testFailing?: boolean;
 };
@@ -99,6 +105,12 @@ function createJestMismatchMessage(testName: string, mismatchedPixels: number): 
         : `Received PNG snapshot does not match the stored snapshot for "${testName}" (${mismatchLabel}).`;
 }
 
+function createJestNegatedMatchMessage(testName: string): string {
+    return testName === ''
+        ? 'Received PNG snapshot matches the stored snapshot, but was expected to differ.'
+        : `Received PNG snapshot matches the stored snapshot for "${testName}", but was expected to differ.`;
+}
+
 function createJestMissingSnapshotMessage(testName: string): string {
     return testName === ''
         ? 'New PNG snapshot was not written. Run Jest with -u to create it.'
@@ -125,6 +137,32 @@ const toMatchPngSnapshot = createPngSnapshotMatcher((matcherContext, received, a
     const snapshotData = getSnapshotData(snapshotState);
     const storedSnapshot = snapshotData[key];
     const updateSnapshot = getUpdateSnapshotMode(snapshotState);
+
+    // `.not` asserts the received PNG differs from the stored snapshot. It never
+    // writes or updates a snapshot, and it returns the raw comparison result:
+    // the framework inverts `pass` for the negated assertion.
+    if (context.isNot === true) {
+        if (storedSnapshot === undefined) {
+            throw new Error(NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE);
+        }
+
+        const comparison = compareAgainstSerializedPngSnapshot(received, storedSnapshot, args.options);
+
+        if (!comparison.pass) {
+            return {
+                pass: false,
+                message: () => '',
+            };
+        }
+
+        incrementSnapshotCounter(snapshotState, 'unmatched');
+        return {
+            pass: true,
+            actual: comparison.actualSerialized,
+            expected: comparison.expectedSerialized,
+            message: () => createJestNegatedMatchMessage(testName),
+        };
+    }
 
     if (storedSnapshot !== undefined) {
         const comparison = compareAgainstSerializedPngSnapshot(received, storedSnapshot, args.options);

--- a/src/matchers/createPngSnapshotMatcher.ts
+++ b/src/matchers/createPngSnapshotMatcher.ts
@@ -57,22 +57,33 @@ export function createPngSnapshotMatcher(delegate: SnapshotMatcherDelegate) {
         hintOrOptions?: string | ComparePngOptions,
         options?: ComparePngOptions,
     ) {
-        if (this.isNot === true) {
-            throw new Error('.not.toMatchPngSnapshot() is not supported.');
-        }
+        // Guard failures are reported as `pass: false`, which the framework
+        // inverts under `.not` into a passing assertion. Throwing instead keeps
+        // invalid input loud in both directions.
+        const isNot = this.isNot === true;
 
         if (!(received instanceof Uint8Array) || !hasPngSignature(received)) {
+            const errorMessage = `toMatchPngSnapshot() expects a PNG Buffer or Uint8Array, but received ${describeValue(received)}.`;
+
+            if (isNot) {
+                throw new Error(errorMessage);
+            }
+
             return {
                 pass: false,
                 actual: received,
                 expected: 'PNG Buffer or Uint8Array',
-                message: () => `toMatchPngSnapshot() expects a PNG Buffer or Uint8Array, but received ${describeValue(received)}.`,
+                message: () => errorMessage,
             };
         }
 
         const normalizedArgs = normalizePngSnapshotMatcherArgs(hintOrOptions, options);
 
         if ('errorMessage' in normalizedArgs) {
+            if (isNot) {
+                throw new Error(normalizedArgs.errorMessage);
+            }
+
             return {
                 pass: false,
                 actual: hintOrOptions,

--- a/src/matchers/pngSnapshot.ts
+++ b/src/matchers/pngSnapshot.ts
@@ -22,6 +22,13 @@ type SerializedPngSnapshot = {
     type: 'Buffer';
 };
 
+/**
+ * Thrown by `.not.toMatchPngSnapshot()` when there is no stored snapshot to
+ * compare against. A missing baseline must never pass vacuously — you cannot
+ * record what an image must *not* be.
+ */
+export const NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE = '.not.toMatchPngSnapshot() requires an existing snapshot to compare against.';
+
 export type ComparedPngSnapshot = {
     pass: boolean;
     mismatchedPixels: number;

--- a/src/vitest.mts
+++ b/src/vitest.mts
@@ -4,7 +4,12 @@
 import { chai, expect } from 'vitest';
 import type { MatcherState } from 'vitest';
 import { createPngSnapshotMatcher } from './matchers/createPngSnapshotMatcher.js';
-import { buildSnapshotTestName, compareAgainstSerializedPngSnapshot, type PngSnapshotMatcherArgs } from './matchers/pngSnapshot.js';
+import {
+    buildSnapshotTestName,
+    compareAgainstSerializedPngSnapshot,
+    NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE,
+    type PngSnapshotMatcherArgs,
+} from './matchers/pngSnapshot.js';
 import type { ComparePngOptions } from './types/index.js';
 
 declare module 'vitest' {
@@ -102,6 +107,26 @@ const toMatchPngSnapshot = createPngSnapshotMatcher((matcherContext: unknown, re
     });
 
     expectedSnapshot.markAsChecked();
+
+    // `.not` asserts the received PNG differs from the stored snapshot. The
+    // probe above already claimed the key so it is not reported obsolete;
+    // `processDomainSnapshot` is deliberately skipped because it owns pass/fail,
+    // file writes and counter updates, none of which apply to a negated
+    // assertion. The framework inverts `pass` for us.
+    if (context.isNot === true) {
+        if (expectedSnapshot.data === undefined) {
+            throw new Error(NOT_REQUIRES_STORED_SNAPSHOT_MESSAGE);
+        }
+
+        const negatedComparison = compareAgainstSerializedPngSnapshot(received, expectedSnapshot.data, args.options);
+
+        return {
+            pass: negatedComparison.pass,
+            actual: negatedComparison.actualSerialized.trim(),
+            expected: negatedComparison.expectedSerialized.trim(),
+            message: () => `Snapshot \`${expectedSnapshot.key}\` matched but was expected to differ`,
+        };
+    }
 
     const comparison =
         expectedSnapshot.data === undefined


### PR DESCRIPTION
Release **6.3.0**. Closes #106.

## `.not.toMatchPngSnapshot()`

`expect(received).not.toMatchPngSnapshot()` now asserts the received PNG **differs** from the stored snapshot. Previously every negated assertion threw `.not.toMatchPngSnapshot() is not supported.`

- Passes when the PNGs differ beyond the configured threshold; fails when they match.
- Never writes or updates a snapshot, even under `-u` — you cannot record what an image must *not* be.
- Throws when no snapshot is stored, rather than passing vacuously on a missing baseline.

### Two design decisions worth reviewing

**The delegate does not invert `pass`.** Issue #106 proposed inverting inside the delegate. That would make `.not` backwards: `expect.extend` semantics already fail a negated assertion when the matcher returns `pass: true`. Verified empirically against Vitest 4.1.10 with a probe matcher — under `.not`, `pass: false` → assertion passes, `pass: true` → assertion fails and `message()` is called. The delegate returns the raw comparison result and only varies `message()`.

**The argument guards now throw when negated.** `createPngSnapshotMatcher` reported invalid input (non-PNG value, malformed matcher args) as `pass: false`. Under `.not` the framework inverts that into a *passing* assertion, so `expect('not a png').not.toMatchPngSnapshot()` would have silently passed. Both guards now throw when `isNot` is set — the same false-green class of bug #103 was about.

The Vitest delegate probes the snapshot read-only (`probeExpectedSnapshot` + `markAsChecked`, so the key is not reported obsolete) and skips `processDomainSnapshot` entirely, since that owns pass/fail, file writes and counter updates. The Jest delegate moves `unmatched` only on a failing `.not` and never touches `added`/`updated`/`matched`.

## Also in this release

TypeScript 7 migration and dependency refreshes that landed since 6.2.0. **Not consumer-visible**: `out/` built with TS7 vs TS6 differs only in `.d.ts` quote style and one union member ordering — semantically identical.

## Test plan

- [x] `npm run test:unit` — 414 tests, 100% coverage held (540/540 statements, 403/403 branches, 91/91 functions)
- [x] `npm run test:e2e` — 47 passed
- [x] `npm run release:check:pre` — all 6 gates pass for 6.3.0
- [x] End-to-end proof through real Vitest against committed snapshots: `.not` vs a different PNG passes; vs the same PNG throws ``Snapshot `…` matched but was expected to differ``; no snapshot written, none reported obsolete
- [x] Rewrote the two tests that asserted the old throw (`pngSnapshotMatcher.test.ts:119`, `:280`) rather than deleting them
