### PR TITLE
ci: only upgrade npm when below the Trusted Publishing floor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,21 @@ jobs:
                   node-version-file: .nvmrc
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
+            # Only upgrade when the runner's npm is below the Trusted Publishing
+            # floor. Installing npm@latest unconditionally couples this job to
+            # whatever Node range the newest npm demands: npm@12 requires Node
+            # ^22.22.2 || ^24.15.0 || >=26.0.0 and hard-fails EBADENGINE against
+            # the Node pinned in .nvmrc, even though the preinstalled npm
+            # already satisfies 11.5.1.
             - name: Ensure npm supports Trusted Publishing (>= 11.5.1)
-              run: npm install -g npm@latest
+              run: |
+                  current="$(npm --version)"
+                  if [ "$(printf '%s\n%s\n' "$current" '11.5.1' | sort -V | head -n1)" = '11.5.1' ]; then
+                      echo "npm $current already satisfies >= 11.5.1"
+                  else
+                      echo "npm $current is below 11.5.1; upgrading within the 11.x line"
+                      npm install -g 'npm@^11.5.1'
+                  fi
             - run: npm ci
             - run: npx playwright install --with-deps chromium
             - run: npm audit --audit-level=high


### PR DESCRIPTION
The 6.3.0 publish run ([30403560005](https://github.com/dichovsky/png-visual-compare/actions/runs/30403560005)) failed at step 4 of 11.

## Root cause

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"node":"v24.14.1","npm":"11.11.0"}
```

`npm install -g npm@latest` now resolves to npm@12.0.1. `.nvmrc` pins Node **v24.14.1**, which sits just under npm 12's `^24.15.0` floor, so the install aborts and fails the job.

The step's name already stated the real requirement — **>= 11.5.1**, the Trusted Publishing minimum — but its command chased `latest`. The runner already ships **npm 11.11.0**, so no upgrade was ever needed. npm 12's release simply exposed the drift between the step's stated intent and what it actually ran.

## Fix

Compare the installed npm against the 11.5.1 floor and upgrade only when it falls short, staying within the 11.x line. The job no longer tracks whatever Node range the newest npm happens to demand.

Bumping `.nvmrc` to Node ≥ 24.15.0 would also have unblocked this release, but it leaves the same trap armed for the next npm major.

## Verification

Logic checked against the boundary cases, including `11.11.0` vs `11.5.1` where a naive string compare gives the wrong answer:

| installed | result |
|---|---|
| 11.11.0 | skip (satisfies) |
| 11.5.1 | skip (satisfies) |
| 12.0.1 | skip (satisfies) |
| 11.20.0 | skip (satisfies) |
| 11.5.0 | upgrade |
| 11.4.0 | upgrade |
| 9.0.0 | upgrade |

`sort -V` is GNU sort on the `ubuntu-24.04` runner. `prettier --check` passes.

## Release impact

**Nothing was published.** The job died before `npm ci`, `npm run build`, `release:check:pre`, and `npm publish`. npm `latest` is still 6.2.0 and `png-visual-compare@6.3.0` returns 404, so 6.3.0 can be re-released cleanly once this lands.
